### PR TITLE
Factor out an add_common_arguments() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TREX is an experimental workflow that enables simultaneous lineage TRacking and 
 
 An essential part of this workflow is presented here: the extraction of genetic barcodes or "cloneIDs" from single-cell transcriptomes and the reconstruction of related cells.
 
-The computational tool uses BAM files of one or multiple sequencing libraries as an input for the generation of cloneID count matrices and identifies clonally related cells based on Jaccard similarity between each pair of cloneID+cells. 
+The tool uses BAM files of one or multiple sequencing libraries as an input for the generation of cloneID count matrices and identifies clonally related cells based on Jaccard similarity between each pair of cloneID+cells.
 
 Currently, TREX is compatible with common RNA-sequencing library preparation methods and data formats provided by 10X Chromium and 10X Visium.
 
@@ -82,17 +82,17 @@ This is an overview of the steps that the `trex run10x` command performs.
    - It aligns to the region specified with the `--chr`, `-s` and
      `-e` flags or, if the flags are not given, to the region that
      has been automatically identified to be the region containing
-     the variable CloneID sequence,
+     the variable cloneID sequence,
    - it has both an associated cell ID and UMI (SAM tags `CB` and `UB`),
    - its cell ID is included in the list of allowed cell IDs
      (if such a list is provided with `--filter-cellid` or `-f`).
 2. Group reads with identical cell ID and UMI into *molecules*.
-   The clone ID of the molecule is taken to be the consensus of the clone IDs.
-3. Error-correct clone IDs of the molecules.
+   The cloneID of the molecule is taken to be the consensus of the cloneIDs.
+3. Error-correct cloneIDs of the molecules.
 4. Group molecules by cell ID into cells.
-5. Filter bad clone IDs in each cell:
-   Rare clone IDs also found in another cell are considered to be contaminants.
-   Clone IDs supported by only a single read are removed.
+5. Filter bad cloneIDs in each cell:
+   Rare cloneIDs also found in another cell are considered to be contaminants.
+   CloneIDs supported by only a single read are removed.
 6. Cluster the cells into clones by creating a *clone graph*.
    Edges are drawn between cells that appear to belong to the same clone.
    The connected components of the graph are considered to be the clones.
@@ -145,7 +145,7 @@ Example:
 
 ### `molecules_corrected.txt`
 
-A table with molecules where clone IDs have been error corrected.
+A table with molecules where cloneIDs have been error corrected.
 
 The file is the same as `molecules.txt` with some changes in the *clone_id*
 column.
@@ -155,7 +155,7 @@ column.
 
 A table listing the detected cells.
 The fields are *cell_id*, a colon (`:`) and then
-pairs of columns *clone_id1* and *count1* for each clone ID found in that cell.
+pairs of columns *clone_id1* and *count1* for each cloneID found in that cell.
 Example:
 
     #cell_id          :  clone_id1                       count1  clone_id2 count2  ...
@@ -165,13 +165,13 @@ Example:
 
 ### `cells_filtered.txt`
 
-The same as `cells.txt`, but with error-corrected clone ID counts.
-Cells that end up without any clone IDs after error correction are removed.
+The same as `cells.txt`, but with error-corrected cloneID counts.
+Cells that end up without any cloneIDs after error correction are removed.
 
 
 ### `umi_count_matrix.csv`
 
-A matrix of UMI counts with cells as columns and clone IDs as rows.
+A matrix of UMI counts with cells as columns and cloneIDs as rows.
 
 Only created if option `--umi-matrix` is used.
 
@@ -207,7 +207,7 @@ identifies the clone.
 
 ### `clone_sequences.txt`
 
-A table listing the 30N sequence of each clone ID.
+A table listing the 30N sequence of each cloneID.
 The columns are *clone_id* and *clone_seq* where *clone_id* is a number
 that identifies the clone and *clone_seq* its nucleotide sequence.
 

--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -66,14 +66,14 @@ def add_common_arguments(parser, smartseq: bool):
     input_group.add_argument(
         "--chromosome",
         "--chr",
-        help="Name of chromosome on which clone ID is located. "
+        help="Name of chromosome on which cloneID is located. "
         "Default: Last chromosome in BAM file",
         default=None,
     )
     input_group.add_argument(
         "--start",
         "-s",
-        help="Position of first clone ID nucleotide (1-based). Default: Auto-detected",
+        help="Position of first cloneID nucleotide (1-based). Default: Auto-detected",
         type=int,
         metavar="INT",
         default=None,
@@ -81,7 +81,7 @@ def add_common_arguments(parser, smartseq: bool):
     input_group.add_argument(
         "--end",
         "-e",
-        help="Position of last clone ID nucleotide (1-based). Default: Auto-detected",
+        help="Position of last cloneID nucleotide (1-based). Default: Auto-detected",
         type=int,
         metavar="INT",
         default=None,
@@ -89,12 +89,12 @@ def add_common_arguments(parser, smartseq: bool):
     if smartseq:
         help = (
             "Path to united BAM file for all cells or path to a folder with one BAM file "
-            "per cell, containing sequencing of the clone ID amplicon library."
+            "per cell, containing sequencing of the cloneID amplicon library."
         )
     else:
         help = (
             "Path to Cell Ranger result directory (a subdirectory 'outs' must exist) "
-            "containing sequencing of the clone ID amplicon library."
+            "containing sequencing of the cloneID amplicon library."
         )
     input_group.add_argument(
         "--amplicon",
@@ -125,14 +125,14 @@ def add_common_arguments(parser, smartseq: bool):
     filter_group.add_argument(
         "--min-length",
         "-m",
-        help="Minimum number of nucleotides a clone ID must have. Default: %(default)s",
+        help="Minimum number of nucleotides a cloneID must have. Default: %(default)s",
         type=int,
         metavar="INT",
         default=20,
     )
     filter_group.add_argument(
         "--max-hamming",
-        help="Maximum hamming distance allowed for two clone IDs to be called similar. "
+        help="Maximum hamming distance allowed for two cloneIDs to be called similar. "
         "Default: %(default)s",
         type=int,
         metavar="INT",
@@ -143,7 +143,7 @@ def add_common_arguments(parser, smartseq: bool):
         type=float,
         default=0,
         metavar="VALUE",
-        help="If the Jaccard index between clone IDs of two cells is higher than VALUE, they "
+        help="If the Jaccard index between cloneIDs of two cells is higher than VALUE, they "
         "are considered similar. Default: %(default)s",
     )
     filter_group.add_argument(

--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -184,7 +184,7 @@ def add_common_arguments(parser, smartseq: bool):
         dest="plot",
         default=False,
         action="store_true",
-        help="Plot the clone graph",
+        help="Plot the clone graph. This requires GraphViz to be installed.",
     )
     optional_group.add_argument(
         "--highlight",

--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -88,7 +88,7 @@ def add_common_arguments(parser, smartseq: bool):
     )
     if smartseq:
         help = (
-            "Path to united bam file for all cells or path to a folder with one bam file "
+            "Path to united BAM file for all cells or path to a folder with one BAM file "
             "per cell, containing sequencing of the clone ID amplicon library."
         )
     else:
@@ -105,7 +105,7 @@ def add_common_arguments(parser, smartseq: bool):
         default=None,
     )
     if smartseq:
-        help = "bam files/bam file directories"
+        help = "BAM files/BAM file directories"
     else:
         help = "Cell Ranger directories"
     input_group.add_argument(
@@ -195,8 +195,8 @@ def add_common_arguments(parser, smartseq: bool):
 
     if smartseq:
         help = (
-            "Path to a united bam file for all cells or path to a folder "
-            "with one bam file per cell."
+            "Path to a united BAM file for all cells or path to a folder "
+            "with one BAM file per cell."
         )
     else:
         help = (

--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -1,7 +1,9 @@
 import logging
 from pathlib import Path
 import shutil
+from types import SimpleNamespace
 
+from .. import __version__
 from trex.utils import NiceFormatter
 
 logger = logging.getLogger(__name__)
@@ -39,3 +41,174 @@ def make_output_dir(path, delete_if_exists):
             path.mkdir()
         else:
             raise
+
+
+def add_common_arguments(parser, smartseq: bool):
+    """Add arguments to an ArgumentParser common to both run10x and smartseq2"""
+
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument(
+        "--debug",
+        default=False,
+        action="store_true",
+        help="Print some extra debugging messages",
+    )
+
+    input_group = parser.add_argument_group("Input")
+
+    input_group.add_argument(
+        "--genome-name",
+        metavar="NAME",
+        help="Name of the genome as indicated in 'cellranger count' run with the flag --genome. "
+        "Default: Auto-detected",
+        default=None,
+    )
+    input_group.add_argument(
+        "--chromosome",
+        "--chr",
+        help="Name of chromosome on which clone ID is located. "
+        "Default: Last chromosome in BAM file",
+        default=None,
+    )
+    input_group.add_argument(
+        "--start",
+        "-s",
+        help="Position of first clone ID nucleotide (1-based). Default: Auto-detected",
+        type=int,
+        metavar="INT",
+        default=None,
+    )
+    input_group.add_argument(
+        "--end",
+        "-e",
+        help="Position of last clone ID nucleotide (1-based). Default: Auto-detected",
+        type=int,
+        metavar="INT",
+        default=None,
+    )
+    if smartseq:
+        help = (
+            "Path to united bam file for all cells or path to a folder with one bam file "
+            "per cell, containing sequencing of the clone ID amplicon library."
+        )
+    else:
+        help = (
+            "Path to Cell Ranger result directory (a subdirectory 'outs' must exist) "
+            "containing sequencing of the clone ID amplicon library."
+        )
+    input_group.add_argument(
+        "--amplicon",
+        "-a",
+        nargs="+",
+        metavar="DIRECTORY",
+        help=help + " Provide these in the same order as transcriptome datasets",
+        default=None,
+    )
+    if smartseq:
+        help = "bam files/bam file directories"
+    else:
+        help = "Cell Ranger directories"
+    input_group.add_argument(
+        "--samples",
+        help="Sample names separated by comma, in the same order as " + help,
+        default=None,
+    )
+    input_group.add_argument(
+        "--prefix",
+        default=False,
+        action="store_true",
+        help="Add sample name as prefix to cell IDs. Default: Add as suffix",
+    )
+
+    filter_group = parser.add_argument_group("Filter settings")
+
+    filter_group.add_argument(
+        "--min-length",
+        "-m",
+        help="Minimum number of nucleotides a clone ID must have. Default: %(default)s",
+        type=int,
+        metavar="INT",
+        default=20,
+    )
+    filter_group.add_argument(
+        "--max-hamming",
+        help="Maximum hamming distance allowed for two clone IDs to be called similar. "
+        "Default: %(default)s",
+        type=int,
+        metavar="INT",
+        default=5,
+    )
+    filter_group.add_argument(
+        "--jaccard-threshold",
+        type=float,
+        default=0,
+        metavar="VALUE",
+        help="If the Jaccard index between clone IDs of two cells is higher than VALUE, they "
+        "are considered similar. Default: %(default)s",
+    )
+    filter_group.add_argument(
+        "--filter-cellids",
+        "-f",
+        metavar="CSV",
+        type=Path,
+        help="CSV file containing cell IDs to keep in the analysis. "
+        "This flag enables to remove cells e.g. doublets",
+        default=None,
+    )
+
+    output_group = parser.add_argument_group("Output directory")
+
+    output_group.add_argument(
+        "--output",
+        "-o",
+        "--name",
+        "-n",
+        metavar="DIRECTORY",
+        type=Path,
+        help="Name of the run directory to be created by the program. Default: %(default)s",
+        default=Path("trex_run"),
+    )
+    output_group.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete the run directory if it already exists",
+    )
+
+    optional_group = parser.add_argument_group(
+        "Optional output files",
+        description="Use these options to enable creation "
+        "of additional files in the output directory",
+    )
+    optional_group.add_argument(
+        "--plot",
+        dest="plot",
+        default=False,
+        action="store_true",
+        help="Plot the clone graph",
+    )
+    optional_group.add_argument(
+        "--highlight",
+        metavar="FILE",
+        help="Highlight cell IDs listed in FILE "
+        "(text file with one cell ID per line) in the clone graph",
+    )
+
+    if smartseq:
+        help = (
+            "Path to a united bam file for all cells or path to a folder "
+            "with one bam file per cell."
+        )
+    else:
+        help = (
+            "Path to the input Cell Ranger directories. "
+            "There must be an 'outs' subdirectory in each of these directories."
+        )
+    parser.add_argument(
+        "path",
+        type=Path,
+        nargs="+",
+        metavar="DIRECTORY",
+        help=help,
+    )
+
+    return SimpleNamespace(input=input_group, filter=filter_group, output=output_group)

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -117,13 +117,13 @@ def add_arguments(parser):
         "--keep-single-reads",
         action="store_true",
         default=False,
-        help="Keep clone IDs supported by only a single read. Default: Discard them",
+        help="Keep cloneIDs supported by only a single read. Default: Discard them",
     )
     groups.filter.add_argument(
         "--visium",
         default=False,
         action="store_true",
-        help="Adjust filter settings for 10x Visium data: Filter out clone IDs only based on "
+        help="Adjust filter settings for 10x Visium data: Filter out cloneIDs only based on "
         "one read, but keep those with only one UMI",
     )
 
@@ -139,7 +139,7 @@ def add_arguments(parser):
         default=False,
         action="store_true",
         help="Create a UMI count matrix 'umi_count_matrix.csv' with "
-        "cells as columns and clone IDs as rows",
+        "cells as columns and cloneIDs as rows",
     )
 
 
@@ -180,8 +180,8 @@ def run_trex(
         r.clone_id for r in reads if "-" not in r.clone_id and "0" not in r.clone_id
     ]
     logger.info(
-        f"Read {len(reads)} reads containing (parts of) the clone ID "
-        f"({len(clone_ids)} full clone IDs, {len(set(clone_ids))} unique)"
+        f"Read {len(reads)} reads containing (parts of) the cloneID "
+        f"({len(clone_ids)} full cloneIDs, {len(set(clone_ids))} unique)"
     )
 
     write_reads_or_molecules(output_dir / "reads.txt", reads)
@@ -191,7 +191,7 @@ def run_trex(
         m.clone_id for m in molecules if "-" not in m.clone_id and "0" not in m.clone_id
     ]
     logger.info(
-        f"Detected {len(molecules)} molecules ({len(clone_ids)} full clone IDs, "
+        f"Detected {len(molecules)} molecules ({len(clone_ids)} full cloneIDs, "
         f"{len(set(clone_ids))} unique)"
     )
 
@@ -204,7 +204,7 @@ def run_trex(
         if "-" not in m.clone_id and "0" not in m.clone_id
     ]
     logger.info(
-        f"After clone ID correction, {len(set(clone_ids))} unique clone IDs remain"
+        f"After cloneID correction, {len(set(clone_ids))} unique cloneIDs remain"
     )
 
     write_reads_or_molecules(
@@ -304,12 +304,12 @@ def correct_clone_ids(
     molecules: List[Molecule], max_hamming: int, min_overlap: int = 20
 ) -> List[Molecule]:
     """
-    Attempt to correct sequencing errors in the clone ID sequences of all molecules
+    Attempt to correct sequencing errors in the cloneID sequences of all molecules
     """
-    # Obtain all clone IDs (including those with '-' and '0')
+    # Obtain all cloneIDs (including those with '-' and '0')
     clone_ids = [m.clone_id for m in molecules]
 
-    # Count the full-length clone IDs
+    # Count the full-length cloneIDs
     counts = Counter(clone_ids)
 
     # Cluster them by Hamming distance
@@ -329,16 +329,16 @@ def correct_clone_ids(
 
     clusters = cluster_sequences(list(set(clone_ids)), is_similar=is_similar, k=7)
 
-    # Map non-singleton clone IDs to a cluster representative
+    # Map non-singleton cloneIDs to a cluster representative
     clone_id_map = dict()
     for cluster in clusters:
         if len(cluster) > 1:
-            # Pick most frequent clone ID as representative
+            # Pick most frequent cloneID as representative
             representative = max(cluster, key=lambda bc: (counts[bc], bc))
             for clone_id in cluster:
                 clone_id_map[clone_id] = representative
 
-    # Create a new list of molecules in which the clone IDs have been replaced
+    # Create a new list of molecules in which the cloneIDs have been replaced
     # by their representatives
     new_molecules = []
     for molecule in molecules:
@@ -352,7 +352,7 @@ def filter_visium(
     molecules: Iterable[Molecule],
 ) -> List[Cell]:
     """
-    Filter: clone IDs that have only a count of one and are also only based on one read are  removed
+    Filter: cloneIDs that have only a count of one and are also only based on one read are  removed
     """
     new_cells = []
     del_cells = 0
@@ -362,7 +362,7 @@ def filter_visium(
         counts = cell.counts.copy()
         for clone_id, count in cell.counts.items():
             if count > 1:
-                # This clone ID occurs more than once in this cell - keep it
+                # This cloneID occurs more than once in this cell - keep it
                 continue
             for molecule in molecules:
                 if (
@@ -370,7 +370,7 @@ def filter_visium(
                     and molecule.clone_id == clone_id
                     and molecule.read_count == 1
                 ):
-                    # This clone ID has only a read count of 1 - remove it
+                    # This cloneID has only a read count of 1 - remove it
                     del_cloneids += 1
                     del counts[clone_id]
         if counts:
@@ -379,7 +379,7 @@ def filter_visium(
             del_cells += 1
 
     logger.info(
-        f"Found {del_cloneids} single-read clone IDs and removed {del_cells} cells"
+        f"Found {del_cloneids} single-read cloneIDs and removed {del_cells} cells"
     )
     return new_cells
 
@@ -390,11 +390,11 @@ def filter_cells(
     keep_single_reads: bool = False,
 ) -> List[Cell]:
     """
-    Filter clone IDs according to two criteria:
+    Filter cloneIDs according to two criteria:
 
-    - Clone ids that have only a count of one and can be found in another cell are most
+    - CloneIDs that have only a count of one and can be found in another cell are most
       likely results of contamination and are removed,
-    - If keep_single_reads is False, clone IDs that have only a count of one and are also only based
+    - If keep_single_reads is False, cloneIDs that have only a count of one and are also only based
       on one read are also removed
     """
     overall_counts: Dict[str, int] = Counter()
@@ -405,18 +405,18 @@ def filter_cells(
     for molecule in molecules:
         if molecule.read_count == 1:
             single_read_clone_ids.add(molecule.clone_id)
-    logger.info(f"Found {len(single_read_clone_ids)} single-read clone IDs")
+    logger.info(f"Found {len(single_read_clone_ids)} single-read cloneIDs")
 
-    # filters out clone IDs with a count of one that appear in another cell
+    # Filter out cloneIDs with a count of one that appear in another cell
     new_cells = []
     for cell in cells:
         counts = cell.counts.copy()
         for clone_id, count in cell.counts.items():
             if count > 1:
-                # This clone ID occurs more than once in this cell - keep it
+                # This cloneID occurs more than once in this cell - keep it
                 continue
             if overall_counts[clone_id] > 1:
-                # This clone ID occurs also in other cells - remove it
+                # This cloneID occurs also in other cells - remove it
                 del counts[clone_id]
             elif clone_id in single_read_clone_ids and not keep_single_reads:
                 del counts[clone_id]

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -101,7 +101,7 @@ def add_arguments(parser):
         "--readcount-threshold",
         default=2,
         type=int,
-        help="Minimum number of reads supporting a clone ID "
+        help="Minimum number of reads supporting a cloneID "
         "in order to keep it for downstream analysis. "
         "Default: %(default)s",
     )
@@ -110,7 +110,7 @@ def add_arguments(parser):
         default=False,
         action="store_true",
         help="Create a read count matrix 'read_count_matrix.csv' "
-             "with cells as columns and clone IDs as rows",
+             "with cells as columns and cloneIDs as rows",
     )
 
 
@@ -154,8 +154,8 @@ def run_smartseq2(
         r.clone_id for r in reads if "-" not in r.clone_id and "0" not in r.clone_id
     ]
     logger.info(
-        f"Read {len(reads)} reads containing (parts of) the clone ID "
-        f"({len(clone_ids)} full clone IDs, {len(set(clone_ids))} unique)"
+        f"Read {len(reads)} reads containing (parts of) the cloneID "
+        f"({len(clone_ids)} full cloneIDs, {len(set(clone_ids))} unique)"
     )
 
     write_reads_or_molecules(output_dir / "reads.txt", reads, require_umis=False)
@@ -170,7 +170,7 @@ def run_smartseq2(
         if "-" not in m.clone_id and "0" not in m.clone_id
     ]
     logger.info(
-        f"After clone ID correction, {len(set(clone_ids))} unique clone IDs remain"
+        f"After cloneID correction, {len(set(clone_ids))} unique cloneIDs remain"
     )
 
     write_reads_or_molecules(
@@ -234,7 +234,7 @@ def filter_smartseq(
     cells: Iterable[Cell], molecules: Iterable[Molecule], readcount_threshold: int
 ) -> List[Cell]:
     """
-    Removes clone IDs that are supported by less reads than the given readcount_threshold
+    Remove cloneIDs that are supported by less reads than the given readcount_threshold
     """
     new_cells = []
     for cell in cells:

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -109,7 +109,8 @@ def add_arguments(parser):
         "--read-matrix",
         default=False,
         action="store_true",
-        help="Creates a read count matrix with cells as columns and clone IDs as rows",
+        help="Create a read count matrix 'read_count_matrix.csv' "
+             "with cells as columns and clone IDs as rows",
     )
 
 

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from collections import Counter
 from typing import List, Iterable
 
+import trex.cli
 from .run10x import read_allowed_cellids, correct_clone_ids
 from . import setup_logging, CommandLineError, add_file_logging, make_output_dir
 from .. import __version__
@@ -94,135 +95,21 @@ def main(args):
 
 
 def add_arguments(parser):
-    parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument(
-        "--debug",
-        default=False,
-        action="store_true",
-        help="Print some extra debugging messages",
-    )
-    parser.add_argument(
-        "--genome-name",
-        metavar="NAME",
-        help="Name of the genome as indicated in Cell Ranger count run with the flag --genome. "
-        "Default: None",
-        default=None,
-    )
-    parser.add_argument(
-        "--chromosome",
-        "--chr",
-        help="Name of chromosome on which clone ID is located."
-        " Default: Last chromosome in BAM file",
-        default=None,
-    )
-    parser.add_argument(
-        "--output",
-        "-o",
-        "--name",
-        "-n",
-        metavar="DIRECTORY",
-        type=Path,
-        help="name of the run and directory created by program. Default: %(default)s",
-        default=Path("trex_run"),
-    )
-    parser.add_argument(
-        "--delete", action="store_true", help="Delete output directory if it exists"
-    )
-    parser.add_argument(
-        "--start",
-        "-s",
-        help="Position of first clone ID nucleotide. Default: Auto-detected",
-        type=int,
-        default=None,
-    )
-    parser.add_argument(
-        "--end",
-        "-e",
-        help="Position of last clone ID nucleotide. Default: Auto-detected",
-        type=int,
-        default=None,
-    )
-    parser.add_argument(
-        "--min-length",
-        "-m",
-        help="Minimum number of nucleotides a clone ID must have. Default: %(default)s",
-        type=int,
-        default=20,
-    )
-    parser.add_argument(
-        "--max-hamming",
-        help="Maximum hamming distance allowed for two clone IDs to be called similar. "
-        "Default: %(default)s",
-        type=int,
-        default=5,
-    )
-    parser.add_argument(
-        "--jaccard-threshold",
-        type=float,
-        default=0,
-        metavar="VALUE",
-        help="If the Jaccard index between clone IDs of two cells is higher than VALUE, the cells "
-        "are considered similar. Default: %(default)s",
-    )
-    parser.add_argument(
-        "--amplicon",
-        "-a",
-        nargs="+",
-        metavar="DIRECTORY",
-        help="Path to united bam file for all cells or path to a folder with one bam file per cell,"
-        "containing sequencing of the clone ID amplicon library. Provide these in "
-        "same order as transcriptome datasets",
-        default=None,
-    )
-    parser.add_argument(
-        "--filter-cellids",
-        "-f",
-        metavar="CSV",
-        type=Path,
-        help="CSV file containing cell IDs to keep in the analysis."
-        " This flag enables to remove cells e.g. doublets",
-        default=None,
-    )
-    parser.add_argument(
+    groups = trex.cli.add_common_arguments(parser, smartseq=True)
+
+    groups.filter.add_argument(
         "--readcount-threshold",
         default=2,
         type=int,
-        help="Minimum number of reads supporting a clone ID in order to keep it for downstream analysis. "
+        help="Minimum number of reads supporting a clone ID "
+        "in order to keep it for downstream analysis. "
         "Default: %(default)s",
     )
-    parser.add_argument(
-        "--highlight", help="Highlight cell IDs listed in FILE in the clone graph"
-    )
-    parser.add_argument(
-        "--samples",
-        help="Sample names separated by comma, in the same order as bam files/bam file directories",
-        default=None,
-    )
-    parser.add_argument(
-        "--prefix",
-        default=False,
-        action="store_true",
-        help="Add sample name as prefix to cell IDs (instead of as suffix)",
-    )
-    parser.add_argument(
+    groups.output.add_argument(
         "--read-matrix",
         default=False,
         action="store_true",
         help="Creates a read count matrix with cells as columns and clone IDs as rows",
-    )
-    parser.add_argument(
-        "--plot",
-        dest="plot",
-        default=False,
-        action="store_true",
-        help="Plot the clone graph",
-    )
-    parser.add_argument(
-        "path",
-        type=Path,
-        nargs="+",
-        metavar="DIRECTORY",
-        help="Path to a united bam file for all cells or path to a folder with one bam file per cell.",
     )
 
 

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -39,7 +39,7 @@ class CloneGraph:
 
     @staticmethod
     def _precluster_cells(cells):
-        """Put cells that have identical sets of clone IDs into a clone"""
+        """Put cells that have identical sets of cloneIDs into a clone"""
         cell_lists = defaultdict(list)
         for cell in cells:
             clone_ids = tuple(sorted(cell.counts))
@@ -53,7 +53,7 @@ class CloneGraph:
     def _make_graph(self):
         """
         Create graph of clones; add edges between pre-clustered clones that
-        share at least one clone id. Return created graph.
+        share at least one cloneID. Return created graph.
         """
         clones = [clone for clone in self._clones if clone.counts]
         graph = Graph(clones)
@@ -121,7 +121,7 @@ class CloneGraph:
 
     def clones(self) -> List[Tuple[str, List[Cell]]]:
         """
-        Compute clones. Return a dict that maps a clone id to a list of cells.
+        Compute clones. Return a dict that maps a cloneID to a list of cells.
         """
         compressed_clusters = [g.nodes() for g in self._graph.connected_components()]
         # Expand the Clone instances into cells
@@ -244,7 +244,7 @@ class UncompressedCloneGraph:
         for i in range(len(cells)):
             for j in range(i + 1, len(cells)):
                 if set(cells[i].counts) & set(cells[j].counts):
-                    # Cell i and j share a clone id
+                    # Cell i and j share a cloneID
                     graph.add_edge(cells[i], cells[j])
         return graph
 
@@ -264,7 +264,7 @@ class UncompressedCloneGraph:
 
     def clones(self) -> Dict[str, List[Cell]]:
         """
-        Compute clones. Return a dict that maps a representative clone id to a list of cells.
+        Compute clones. Return a dict that maps a representative cloneID to a list of cells.
         """
         clusters = [g.nodes() for g in self._graph.connected_components()]
 

--- a/src/trex/molecule.py
+++ b/src/trex/molecule.py
@@ -19,7 +19,7 @@ def compute_molecules(reads: List[Read]) -> List[Molecule]:
     """
     Group reads by cell ID and UMI into molecules.
 
-    The clone id of the molecule is the consensus of the clone ids in the group.
+    The cloneID of the molecule is the consensus of the cloneIDs in the group.
     """
     groups = defaultdict(list)
     for read in reads:

--- a/src/trex/writers.py
+++ b/src/trex/writers.py
@@ -11,7 +11,7 @@ import numpy as np
 
 
 def write_count_matrix(path: Path, cells: List[Cell]):
-    """Create a Read-count matrix with cells as columns and clone IDs as rows"""
+    """Create a Read-count matrix with cells as columns and cloneIDs as rows"""
     clone_ids = set()
     for cell in cells:
         clone_ids.update(clone_id for clone_id in cell.counts)
@@ -90,10 +90,10 @@ def write_reads_or_molecules(path, mols_or_reads, require_umis=True, sort=True):
 def write_loom(cells: List[Cell], cellranger, output_dir, clone_id_length, top_n=6):
     """
     Create a loom file from a Cell Ranger result directory and augment it with information about
-    the most abundant clone IDs and their counts.
+    the most abundant cloneIDs and their counts.
     """
-    # For each cell, collect the most abundant clone IDs and their counts
-    # Maps cell_id to a list of (clone_id, count) pairs that represent the most abundant clone IDs.
+    # For each cell, collect the most abundant cloneIDs and their counts
+    # Maps cell_id to a list of (clone_id, count) pairs that represent the most abundant cloneIDs.
     most_abundant = dict()
     for cell in cells:
         if not cell.counts:
@@ -113,8 +113,8 @@ def write_loom(cells: List[Cell], cellranger, output_dir, clone_id_length, top_n
         # Cell ids in the loom file are prefixed by the sample name and a ':'. Remove that prefix.
         loom_cell_ids = [cell_id[len(sample_name) + 1 :] for cell_id in ds.ca.CellID]
 
-        # Transform clone IDs and count data
-        # brings clone ID data into correct format for loom file.
+        # Transform cloneIDs and count data
+        # brings cloneID data into correct format for loom file.
         # Array must have same shape as all_cellIDs
         clone_id_lists = [[] for _ in range(top_n)]
         count_lists = [[] for _ in range(top_n)]
@@ -128,7 +128,7 @@ def write_loom(cells: List[Cell], cellranger, output_dir, clone_id_length, top_n
                 clone_id_lists[i].append(clone_id)
                 count_lists[i].append(count)
 
-        # Add clone ID and count information to loom file
+        # Add cloneID and count information to loom file
         for i in range(top_n):
             ds.ca[f"cloneid_{i+1}"] = np.array(
                 clone_id_lists[i], dtype="S%r" % clone_id_length

--- a/tests/expected/log.txt
+++ b/tests/expected/log.txt
@@ -1,12 +1,12 @@
-Trex 0.4.dev125+gb6b76db.d20200617
+Trex 0.4.dev150+g2e002b0.d20220427
 Command line arguments: run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
-Reading clone ids from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
-Found 3857 reads with usable clone ids. Skipped 1692 without cell id, 3 without UMI.
-Read 3857 reads containing (parts of) the clone ID (2703 full clone IDs, 71 unique)
-Detected 3800 molecules (2676 full clone IDs, 70 unique)
-After clone ID correction, 6 unique clone IDs remain
+Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
+Found 3857 reads with usable cloneIDs. Skipped 1692 without cell id, 3 without UMI.
+Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)
+Detected 3800 molecules (2676 full cloneIDs, 70 unique)
+After cloneID correction, 6 unique cloneIDs remain
 Detected 1921 cells
-Found 41 single-read clone IDs
+Found 41 single-read cloneIDs
 763 filtered cells remain
 Writing UMI matrix
 Removing 0 bridges from the graph

--- a/tests/expected_smartseq2/log.txt
+++ b/tests/expected_smartseq2/log.txt
@@ -1,9 +1,9 @@
-Trex 0.4.dev115+gb2242a8
+Trex 0.4.dev150+g2e002b0.d20220427
 Command line arguments: smartseq2 --delete --chr EGFP-30N --output trex_smartseq2_run --start 2330 --end 2359 --read-matrix --readcount-threshold 1 tests/data/smartseq2_test.bam
-Reading clone ids from EGFP-30N:2330-2359 in tests/data/smartseq2_test.bam
-Found 286 reads with usable clone ids. Skipped 0 without cell id
-Read 286 reads containing (parts of) the clone ID (135 full clone IDs, 115 unique)
-After clone ID correction, 110 unique clone IDs remain
+Reading cloneIDs from EGFP-30N:2330-2359 in tests/data/smartseq2_test.bam
+Found 286 reads with usable cloneIDs. Skipped 0 without cell id
+Read 286 reads containing (parts of) the cloneID (135 full cloneIDs, 115 unique)
+After cloneID correction, 110 unique cloneIDs remain
 Detected 93 cells
 93 filtered cells remain
 Writing read matrix

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ commands = black --check src/ tests/
 max-line-length = 100
 max-complexity = 13
 select = E,F,W,C90,W504
-extend_ignore = E128,E402
+extend_ignore = E128,E402,E203


### PR DESCRIPTION
The run10x and smartseq2 subcommands share many command-line options.
I made some improvements to the the command-line help for run10x in an
earlier commit. Instead of re-doing these for the smartseq2 subcommand,
move the common options into a separate function.