### PR TITLE
Convert NamedTuples to dataclasses

### DIFF
--- a/src/trex/bam.py
+++ b/src/trex/bam.py
@@ -3,8 +3,9 @@ Extract reads from BAM files
 """
 import logging
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, List
+from typing import List
 from typing import Optional
 
 from pysam import AlignmentFile
@@ -12,7 +13,8 @@ from pysam import AlignmentFile
 logger = logging.getLogger(__name__)
 
 
-class Read(NamedTuple):
+@dataclass(frozen=True)
+class Read:
     umi: Optional[str]
     cell_id: str
     clone_id: str

--- a/src/trex/cell.py
+++ b/src/trex/cell.py
@@ -1,10 +1,12 @@
-from typing import NamedTuple, Dict, List
+from dataclasses import dataclass
+from typing import Dict, List
 from collections import defaultdict, OrderedDict, Counter
 
 from .molecule import Molecule
 
 
-class Cell(NamedTuple):
+@dataclass(frozen=True, order=True)
+class Cell:
     cell_id: str
     counts: Dict[str, int]
 

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -4,6 +4,7 @@ Run on single cell 10X Chromium or spatial Visium data processed by Cell / Space
 import re
 import sys
 import logging
+import dataclasses
 from pathlib import Path
 from collections import Counter, defaultdict
 from typing import List, Dict, Iterable
@@ -383,7 +384,8 @@ def correct_clone_ids(
     new_molecules = []
     for molecule in molecules:
         clone_id = clone_id_map.get(molecule.clone_id, molecule.clone_id)
-        new_molecules.append(molecule._replace(clone_id=clone_id))
+        molecule = dataclasses.replace(molecule, clone_id=clone_id)
+        new_molecules.append(molecule)
     return new_molecules
 
 
@@ -435,7 +437,7 @@ def correct_clone_ids_per_cell(
         if this_correction_map is not None:
             new_clone_id = this_correction_map.get(molecule.clone_id,
                                                   molecule.clone_id)
-            molecule = molecule._replace(clone_id=new_clone_id)
+            molecule = dataclasses.replace(molecule, clone_id=new_clone_id)
         return molecule
 
     # Create a new list of molecules in which the cloneIDs have been replaced

--- a/src/trex/molecule.py
+++ b/src/trex/molecule.py
@@ -1,14 +1,16 @@
 """
 A molecule is a DNA/RNA fragment that has potentially been sequenced multiple times
 """
-from typing import NamedTuple, List
+from dataclasses import dataclass
+from typing import List
 from collections import defaultdict
 import numpy as np
 
 from .bam import Read
 
 
-class Molecule(NamedTuple):
+@dataclass
+class Molecule:
     umi: str
     cell_id: str
     clone_id: str


### PR DESCRIPTION
namedtuples have a couple of issues. For example, they are still tuples under the hood so if you have an instance x, you can use x[0] to access the first attribute, but that’s not what one would expect how an object should behave.

Marked as draft because it conflicts with #33 and/or #36.