### PR TITLE
Per-cell cloneID correction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,5 +3,9 @@
 ## development version
 
 * #7: Set default Jaccard threshold to 0.7 so that it matches R output.
-* #33: Add a `trex qc` subcommand for quality control plots.
+* #33: Added a `trex qc` subcommand for quality control plots.
 * #44: Fix some inconsistencies in the way cloneIDs are error-corrected.
+* #30: Added doublet filtering. Cells that appear to be connected to two
+  subclusters are detected and removed. The cell IDs of detected doublets
+  is written to `doublets.txt`. Doublet detection can be disabled with
+  `--keep-doublets`.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ These are only created if option `--plot` is used.
 
 `graph_corrected.gv` and `graph.gv` are textual descriptions of the graphs in GraphViz format.
 
+### `doublets.txt`
+
+A list of the cell IDs of the cells that were detected to be doublets.
+
 
 ### `clones.txt`
 

--- a/src/trex/graph.py
+++ b/src/trex/graph.py
@@ -18,6 +18,11 @@ class Graph:
         self._nodes[node1].remove(node2)
         self._nodes[node2].remove(node1)
 
+    def remove_node(self, node):
+        for neighbor in list(self._nodes[node]):
+            self._nodes[neighbor] = [n for n in self._nodes[neighbor] if n != node]
+        del self._nodes[node]
+
     def connected_components(self):
         """Return a list of connected components."""
         visited = set()
@@ -61,3 +66,34 @@ class Graph:
     def neighbors(self, node):
         """Return a list of all neighbors of a node"""
         return self._nodes[node]
+
+    def induced_subgraph(self, nodes):
+        nodes_set = set(nodes)
+        new_nodes = {
+            node: [neighbor for neighbor in self._nodes[node] if neighbor in nodes_set]
+            for node in nodes
+        }
+        subgraph = Graph([])
+        subgraph._nodes = new_nodes
+
+        return subgraph
+
+    def count_edges(self) -> int:
+        """Return number of edges"""
+        return sum(len(neighbors) for neighbors in self._nodes.values()) // 2
+
+    def local_cut_vertices(self):
+        """
+        Return all vertices that, when removed, would lead to their neighborhood being split
+        into two or more connected components.
+        """
+        vertices = []
+        for node in self.nodes():
+            neighbors = self.neighbors(node)
+            if len(neighbors) < 2:
+                continue
+            subgraph = self.induced_subgraph(neighbors)
+            if len(subgraph.connected_components()) > 1:
+                vertices.append(node)
+
+        return vertices

--- a/test.sh
+++ b/test.sh
@@ -19,3 +19,6 @@ trex smartseq3 --delete --output trex_smartseq3_run --umi-matrix -s 2330 -e 2359
 diff -u <(sed 1d tests/expected_smartseq3/log.txt) <(sed 1d trex_smartseq3_run/log.txt)
 
 trex qc trex_run
+
+# Ensure --per-cell works
+trex run10x --per-cell --delete -s 695 -e 724 -o trex_per_cell tests/data

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,8 @@ samtools --version > /dev/null
 
 pytest tests
 
-trex run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
+set -x
+trex run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
 diff -ur -xdata.loom -xlog.txt -xentries.bam tests/expected trex_run
 
 diff -u <(samtools view -h --no-PG tests/expected/entries.bam) <(samtools view -h --no-PG trex_run/entries.bam) | head -n 10

--- a/test.sh
+++ b/test.sh
@@ -22,3 +22,4 @@ trex qc trex_run
 
 # Ensure --per-cell works
 trex run10x --per-cell --delete -s 695 -e 724 -o trex_per_cell tests/data
+diff -u <(sed 1d tests/expected_per_cell/log.txt) <(sed 1d trex_per_cell/log.txt)

--- a/tests/expected/log.txt
+++ b/tests/expected/log.txt
@@ -1,5 +1,5 @@
 Trex 0.4.dev220+g35d3306
-Command line arguments: run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
+Command line arguments: run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
 Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
 Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
 Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)

--- a/tests/expected_per_cell/log.txt
+++ b/tests/expected_per_cell/log.txt
@@ -1,0 +1,18 @@
+Trex 0.4.dev220+g35d3306
+Command line arguments: run10x --per-cell --delete -s 695 -e 724 -o trex_per_cell tests/data
+Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
+Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
+Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)
+Detected 3800 molecules (2676 full cloneIDs, 70 unique)
+After cloneID correction, 39 unique cloneIDs remain
+Detected 1835 cells
+Found 103 single-read cloneIDs
+697 filtered cells remain
+Removing 0 bridges from the graph
+Detected 11 clones
+Clone size histogram
+ size count
+    1     8
+    2     1
+    8     1
+  679     1

--- a/tests/expected_per_cell/log.txt
+++ b/tests/expected_per_cell/log.txt
@@ -9,6 +9,9 @@ Detected 1835 cells
 Found 103 single-read cloneIDs
 697 filtered cells remain
 Removing 0 bridges from the graph
+Removing 0 doublets from the graph (first round)
+Removing 0 bridges from the graph (second round)
+Removing 0 doublets from the graph (second round)
 Detected 11 clones
 Clone size histogram
  size count

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,74 @@
+from trex.graph import Graph
+
+import pytest
+
+NODES = list("ABCDEFG")
+
+
+@pytest.fixture
+def graph():
+    graph = Graph(NODES)
+    #
+    # (A) -- (B) -- (C)
+    #  |    /  \
+    #  |  /     \
+    # (D)       (E)
+    #
+    # (F) -- (G)
+    #
+    for edge in ["AB", "BC", "AD", "DB", "BE", "FG"]:
+        graph.add_edge(edge[0], edge[1])
+    return graph
+
+
+def test_nodes(graph):
+    assert graph.nodes() == NODES
+
+
+def test_edges(graph):
+    edges = list(graph.edges())
+    assert sorted(edges) == [("A", "B"), ("A", "D"), ("B", "C"), ("B", "D"), ("B", "E"), ("F", "G")]
+
+
+def test_neighbors(graph):
+    neighbors = graph.neighbors("B")
+    assert sorted(neighbors) == ["A", "C", "D", "E"]
+
+
+def test_remove_edge(graph):
+    graph.remove_edge("C", "B")
+    assert sorted(graph.neighbors("B")) == ["A", "D", "E"]
+
+
+def test_connected_components(graph):
+    components = graph.connected_components()
+    assert len(components) == 2
+    nodes1 = components[0].nodes()
+    nodes2 = components[1].nodes()
+    assert sorted(nodes1) == list("ABCDE")
+    assert sorted(nodes2) == list("FG")
+
+
+def test_remove_node(graph):
+    graph.remove_node("B")
+    assert sorted(graph.nodes()) == list("ACDEFG")
+    assert sorted(graph.neighbors("A")) == ["D"]
+    assert sorted(graph.edges()) == [("A", "D"), ("F", "G")]
+
+
+def test_induced_subgraph(graph):
+    subgraph = graph.induced_subgraph(["A", "B", "D"])
+    nodes = list(subgraph.nodes())
+    assert sorted(nodes) == ["A", "B", "D"]
+    edges = list(subgraph.edges())
+    assert sorted(edges) == [("A", "B"), ("A", "D"), ("B", "D")]
+
+
+def test_count_edges(graph):
+    assert graph.count_edges() == 6
+
+    assert Graph([]).count_edges() == 0
+
+
+def test_local_cut_vertices(graph):
+    assert graph.local_cut_vertices() == ["B"]


### PR DESCRIPTION
I split this out from #36. This PR *only* adds the `--per-cell` command-line option.

As discussed in #36, the `--per-cell` option changes the cloneID correction so that it is performed only using the cloneIDs within a single cell.

Testing this, I noticed a couple of things.

First, it may be an idea to have both the global cloneID correction and the per-cell correction. The problem we currently have is that global cloneID correction is overeager and puts too many cloneIDs into the same cluster. This could also be solved by being a lot stricter with the maximum Hamming distance and the minimum cloneID length. The per-cell correction step can then be much less strict because there much fewer cloneIDs in a cell.

Second, even with `--per-cell`, the clustering is still overeager and puts cloneIDs into the same cluster that should be in separate ones.

Here are a couple of examples. First, one where we can see how it is supposed to look like. These are a couple of cloneIDs found in a single cell. The number denotes how many molecules with that cloneID were found:
```
TGGGGGTCGAGTGATTAGAGGTCGTTATAA 1
AGGGGGTCGAGTGAGTAGAGGTCGTTATAA 1
AGGGGGTCGAGTGATTAGAGGTCGTTATAA 32
AGGGGGTCGAGTGATTAGAGGTAGTTATAA 1
-------CGAGTGATTAGAGGTCGTTATAA 2
---------AGTGATTAGAGGTCGTTATAA 1
-----------------GAGGTCGTTATAA 1
-------------------GGTCGTTATAA 1
```
So there is one cloneID that occurs quite often and is probably the correct one. Then there are a couple of rare cloneIDs that differ in a couple of bases from the most abundant one and/or are shorter than it.

Here, two apparently different cloneIDs end up in the same cluster:
```
TGGATGTGCGGCGATCTGAGCCTGGGAGCT 1
TGAAATTTTCCGTGGGCAGTTTTGTCGGGT 1
TAAAATTTTCCGTGGGCAGTTTTGTCATGT 1
TGAAATTTTCCGTGGGCAGTTTTGTCATGT 28
TGGATGTGCGGCGATCTGACCTCTCGACGG 12
TGGATGTGCGGCGAGCTGACCTCTCGACGG 1
------TTTCCGTGGGCAGTTTTGTCATGT 1
-------------GGGCAGTTTTGTCATGT 1
--------------GGCAGTTTTGTCATGT 1
-----------------GACCTCTCGACGG 1
------------------GTTTTGTCATGT 1
-----------------------GTCATGT 2
```
I’d assume that the two cloneIDs that occur 28 and 12 times are the true sequences and should be in different clusters. Here’s how I think it should look:
```
TGAAATTTTCCGTGGGCAGTTTTGTCATGT 28
TGAAATTTTCCGTGGGCAGTTTTGTCGGGT 1
TAAAATTTTCCGTGGGCAGTTTTGTCATGT 1
------TTTCCGTGGGCAGTTTTGTCATGT 1
-------------GGGCAGTTTTGTCATGT 1
--------------GGCAGTTTTGTCATGT 1
------------------GTTTTGTCATGT 1
-----------------------GTCATGT 2

TGGATGTGCGGCGATCTGACCTCTCGACGG 12
TGGATGTGCGGCGATCTGAGCCTGGGAGCT 1
TGGATGTGCGGCGAGCTGACCTCTCGACGG 1
-----------------GACCTCTCGACGG 1
```
This should probably become a separate issue as the problem likely exists (to a much larger extent) in the global cloneID normalization code as well.