### PR TITLE
Add doublet detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,5 +3,8 @@
 ## development version
 
 * #7: Set default Jaccard threshold to 0.7 so that it matches R output.
-* #33: Add a `trex qc` subcommand for quality control plots.
+* #33: Added a `trex qc` subcommand for quality control plots.
 * #44: Fix some inconsistencies in the way cloneIDs are error-corrected.
+* #30: Added doublet filtering. Cells that appear to be connected to two
+  subclusters are detected and removed. The cell IDs of detected doublets
+  is written to `doublets.txt`. 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,4 +7,5 @@
 * #44: Fix some inconsistencies in the way cloneIDs are error-corrected.
 * #30: Added doublet filtering. Cells that appear to be connected to two
   subclusters are detected and removed. The cell IDs of detected doublets
-  is written to `doublets.txt`. 
+  is written to `doublets.txt`. Doublet detection can be disabled with
+  `--keep-doublets`.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ These are only created if option `--plot` is used.
 
 `graph_corrected.gv` and `graph.gv` are textual descriptions of the graphs in GraphViz format.
 
+### `doublets.txt`
+
+A list of the cell IDs of the cells that were detected to be doublets.
+
 
 ### `clones.txt`
 

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -246,24 +246,31 @@ def run_trex(
         print(
             clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
         )
-    if should_plot:
-        logger.info("Plotting clone graph")
-        clone_graph.plot(output_dir / "graph", highlight_cell_ids)
 
     bridges = clone_graph.bridges()
     logger.info(f"Removing {len(bridges)} bridges from the graph")
     clone_graph.remove_edges(bridges)
-    with open(output_dir / "components_corrected.txt", "w") as components_file:
-        print(
-            clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
-        )
 
     doublets = clone_graph.doublets()
-    logger.info(f"Found {len(doublets)} doublets")
+    logger.info(f"Removing {len(doublets)} doublets from the graph (first round)")
+    clone_graph.remove_nodes(doublets)
+    doublets2 = clone_graph.doublets()
+
+    if should_plot:
+        logger.info("Plotting clone graph")
+        clone_graph.plot(output_dir / "graph", highlight_cell_ids, doublets2)
+
+    logger.info(f"Removing {len(doublets2)} doublets from the graph (second round)")
+    clone_graph.remove_nodes(doublets2)
 
     if should_plot:
         logger.info("Plotting corrected clone graph")
         clone_graph.plot(output_dir / "graph_corrected", highlight_cell_ids)
+
+    with open(output_dir / "components_corrected.txt", "w") as components_file:
+        print(
+            clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
+        )
 
     clones = clone_graph.clones()
     with open(output_dir / "clones.txt", "w") as f:

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -292,7 +292,6 @@ def run_trex(
     )
     number_of_cells_in_clones = sum(k * v for k, v in clone_sizes.items())
     logger.debug("No. of cells in clones: %d", number_of_cells_in_clones)
-    assert len(cells) == number_of_cells_in_clones
 
     if should_write_loom:
         if len(transcriptome_inputs) > 1:

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -101,6 +101,7 @@ def main(args):
             min_length=args.min_length,
             jaccard_threshold=args.jaccard_threshold,
             keep_single_reads=args.keep_single_reads,
+            keep_doublets=args.keep_doublets,
             should_write_umi_matrix=args.umi_matrix,
             should_run_visium=args.visium,
             should_plot=args.plot,
@@ -119,6 +120,12 @@ def add_arguments(parser):
         action="store_true",
         default=False,
         help="Keep cloneIDs supported by only a single read. Default: Discard them",
+    )
+    groups.filter.add_argument(
+        "--keep-doublets",
+        action="store_true",
+        default=False,
+        help="Keep doublets. Default: Detect and remove doublets",
     )
     groups.filter.add_argument(
         "--visium",
@@ -167,6 +174,7 @@ def run_trex(
     min_length: int,
     jaccard_threshold: float,
     keep_single_reads: bool,
+    keep_doublets: bool,
     should_write_umi_matrix: bool,
     should_run_visium: bool,
     should_plot: bool,
@@ -248,23 +256,29 @@ def run_trex(
         )
 
     bridges = clone_graph.bridges()
-    logger.info(f"Removing {len(bridges)} bridges from the graph (first round)")
+    logger.info(f"Removing {len(bridges)} bridges from the graph")
     clone_graph.remove_edges(bridges)
 
-    doublets = clone_graph.doublets()
-    logger.info(f"Removing {len(doublets)} doublets from the graph (first round)")
-    clone_graph.remove_nodes(doublets)
+    if not keep_doublets:
+        doublets = clone_graph.doublets()
+        logger.info(f"Removing {len(doublets)} doublets from the graph (first round)")
+        clone_graph.remove_nodes(doublets)
 
-    bridges2 = clone_graph.bridges()
-    logger.info(f"Removing {len(bridges2)} bridges from the graph (second round)")
-    clone_graph.remove_edges(bridges2)
-    doublets2 = clone_graph.doublets()
-    if should_plot:
-        logger.info("Plotting clone graph")
-        clone_graph.plot(output_dir / "graph", highlight_cell_ids, doublets2)
+        bridges2 = clone_graph.bridges()
+        logger.info(f"Removing {len(bridges2)} bridges from the graph (second round)")
+        clone_graph.remove_edges(bridges2)
+        doublets2 = clone_graph.doublets()
+        if should_plot:
+            logger.info("Plotting clone graph")
+            clone_graph.plot(output_dir / "graph", highlight_cell_ids, doublets2)
 
-    logger.info(f"Removing {len(doublets2)} doublets from the graph (second round)")
-    clone_graph.remove_nodes(doublets2)
+        logger.info(f"Removing {len(doublets2)} doublets from the graph (second round)")
+        clone_graph.remove_nodes(doublets2)
+
+        with open(output_dir / "doublets.txt", "w") as doublets_file:
+            for clone in doublets + doublets2:
+                assert clone.n == 1
+                print(clone.cell_ids[0], file=doublets_file)
 
     if should_plot:
         logger.info("Plotting corrected clone graph")
@@ -274,10 +288,6 @@ def run_trex(
         print(
             clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
         )
-    with open(output_dir / "doublets.txt", "w") as doublets_file:
-        for clone in doublets + doublets2:
-            assert clone.n == 1
-            print(clone.cell_ids[0], file=doublets_file)
 
     clones = clone_graph.clones()
     with open(output_dir / "clones.txt", "w") as f:

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -274,6 +274,10 @@ def run_trex(
         print(
             clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
         )
+    with open(output_dir / "doublets.txt", "w") as doublets_file:
+        for clone in doublets + doublets2:
+            assert clone.n == 1
+            print(clone.cell_ids[0], file=doublets_file)
 
     clones = clone_graph.clones()
     with open(output_dir / "clones.txt", "w") as f:

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -258,6 +258,9 @@ def run_trex(
             clone_graph.components_txt(highlight_cell_ids), file=components_file, end=""
         )
 
+    doublets = clone_graph.doublets()
+    logger.info(f"Found {len(doublets)} doublets")
+
     if should_plot:
         logger.info("Plotting corrected clone graph")
         clone_graph.plot(output_dir / "graph_corrected", highlight_cell_ids)

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -248,14 +248,17 @@ def run_trex(
         )
 
     bridges = clone_graph.bridges()
-    logger.info(f"Removing {len(bridges)} bridges from the graph")
+    logger.info(f"Removing {len(bridges)} bridges from the graph (first round)")
     clone_graph.remove_edges(bridges)
 
     doublets = clone_graph.doublets()
     logger.info(f"Removing {len(doublets)} doublets from the graph (first round)")
     clone_graph.remove_nodes(doublets)
-    doublets2 = clone_graph.doublets()
 
+    bridges2 = clone_graph.bridges()
+    logger.info(f"Removing {len(bridges2)} bridges from the graph (second round)")
+    clone_graph.remove_edges(bridges2)
+    doublets2 = clone_graph.doublets()
     if should_plot:
         logger.info("Plotting clone graph")
         clone_graph.plot(output_dir / "graph", highlight_cell_ids, doublets2)

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -113,6 +113,10 @@ class CloneGraph:
         for node1, node2 in edges:
             self._graph.remove_edge(node1, node2)
 
+    def remove_nodes(self, nodes):
+        for node in nodes:
+            self._graph.remove_node(node)
+
     @staticmethod
     def _expand_clones(clones: List[Clone]) -> List[Cell]:
         """Expand a list of Clone instances into a list of Cells"""

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -96,8 +96,8 @@ class CloneGraph:
     def doublets(self):
         """Find cells that appear to incorrectly connect two unrelated subclusters"""
         cut_vertices = self._graph.local_cut_vertices()
-        # Skip clones that represent multiple cells
-        return [node for node in cut_vertices if node.n > 1]
+        # Skip nodes that represent multiple cells
+        return [node for node in cut_vertices if node.n == 1]
 
     def remove_edges(self, edges):
         for node1, node2 in edges:

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -160,16 +160,16 @@ class CloneGraph:
 
         return [(most_abundant_clone_id(cells), cells) for cells in clusters]
 
-    def plot(self, path, highlight_cell_ids=None, highlight_nodes=None):
+    def plot(self, path, highlight_cell_ids=None, highlight_doublets=None):
         graphviz_path = path.with_suffix(".gv")
         with open(graphviz_path, "w") as f:
-            print(self.dot(highlight_cell_ids, highlight_nodes), file=f)
+            print(self.dot(highlight_cell_ids, highlight_doublets), file=f)
         pdf_path = str(path.with_suffix(".pdf"))
         subprocess.run(["sfdp", "-Tpdf", "-o", pdf_path, graphviz_path], check=True)
 
-    def dot(self, highlight_cell_ids=None, highlight_nodes=None) -> str:
+    def dot(self, highlight_cell_ids=None, highlight_doublets=None) -> str:
         highlight_cell_ids = set(highlight_cell_ids) if highlight_cell_ids is not None else set()
-        highlight_nodes = set(highlight_nodes) if highlight_nodes is not None else set()
+        highlight_doublets = set(highlight_doublets) if highlight_doublets is not None else set()
         max_width = 10
         edge_scaling = (max_width - 1) / math.log(
             max(
@@ -190,7 +190,7 @@ class CloneGraph:
             if self._graph.neighbors(node):
                 width = int(1 + node_scaling * math.log(node.n))
                 intersection = set(node.cell_ids) & highlight_cell_ids
-                if node in highlight_nodes:
+                if node in highlight_doublets:
                     hl = ",fillcolor=orange"
                     hl_label = " (doublet)"
                 elif intersection:

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -93,6 +93,22 @@ class CloneGraph:
                 bridges.append((node1, node2))
         return bridges
 
+    def doublets(self):
+        """Find vertices that appear to incorrectly connect two unrelated subclusters"""
+        doublets = []
+        for node in self._graph.nodes():
+            neighbors = self._graph.neighbors(node)
+            n = len(neighbors)
+            if n < 2:
+                continue
+            # A fully connected subgraph would have this many edges
+            expected_edges = len(neighbors) * (len(neighbors) - 1) / 2
+            actual_edges = self._graph.induced_subgraph(neighbors).count_edges()
+            if actual_edges / expected_edges < 0.5:
+                doublets.append(node)
+
+        return doublets
+
     def remove_edges(self, edges):
         for node1, node2 in edges:
             self._graph.remove_edge(node1, node2)

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -94,9 +94,12 @@ class CloneGraph:
         return bridges
 
     def doublets(self):
-        """Find vertices that appear to incorrectly connect two unrelated subclusters"""
+        """Find cells that appear to incorrectly connect two unrelated subclusters"""
         doublets = []
         for node in self._graph.nodes():
+            # Skip clones that represent multiple cells
+            if node.n > 1:
+                continue
             neighbors = self._graph.neighbors(node)
             if len(neighbors) < 2:
                 continue

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -98,13 +98,10 @@ class CloneGraph:
         doublets = []
         for node in self._graph.nodes():
             neighbors = self._graph.neighbors(node)
-            n = len(neighbors)
-            if n < 2:
+            if len(neighbors) < 2:
                 continue
-            # A fully connected subgraph would have this many edges
-            expected_edges = len(neighbors) * (len(neighbors) - 1) / 2
-            actual_edges = self._graph.induced_subgraph(neighbors).count_edges()
-            if actual_edges / expected_edges < 0.5:
+            subgraph = self._graph.induced_subgraph(neighbors)
+            if len(subgraph.connected_components()) > 1:
                 doublets.append(node)
 
         return doublets

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -156,16 +156,16 @@ class CloneGraph:
 
         return [(most_abundant_clone_id(cells), cells) for cells in clusters]
 
-    def plot(self, path, highlight=None):
+    def plot(self, path, highlight_cell_ids=None):
         graphviz_path = path.with_suffix(".gv")
         with open(graphviz_path, "w") as f:
-            print(self.dot(highlight), file=f)
+            print(self.dot(highlight_cell_ids), file=f)
         pdf_path = str(path.with_suffix(".pdf"))
         subprocess.run(["sfdp", "-Tpdf", "-o", pdf_path, graphviz_path], check=True)
 
-    def dot(self, highlight=None):
-        if highlight is not None:
-            highlight = set(highlight)
+    def dot(self, highlight_cell_ids=None):
+        if highlight_cell_ids is not None:
+            highlight_cell_ids = set(highlight_cell_ids)
         max_width = 10
         edge_scaling = (max_width - 1) / math.log(
             max(
@@ -185,7 +185,7 @@ class CloneGraph:
         for node in self._graph.nodes():
             if self._graph.neighbors(node):
                 width = int(1 + node_scaling * math.log(node.n))
-                intersection = set(node.cell_ids) & highlight
+                intersection = set(node.cell_ids) & highlight_cell_ids
                 hl = ",fillcolor=yellow" if intersection else ""
                 hl_label = f" ({len(intersection)})" if intersection else ""
                 print(

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -95,19 +95,9 @@ class CloneGraph:
 
     def doublets(self):
         """Find cells that appear to incorrectly connect two unrelated subclusters"""
-        doublets = []
-        for node in self._graph.nodes():
-            # Skip clones that represent multiple cells
-            if node.n > 1:
-                continue
-            neighbors = self._graph.neighbors(node)
-            if len(neighbors) < 2:
-                continue
-            subgraph = self._graph.induced_subgraph(neighbors)
-            if len(subgraph.connected_components()) > 1:
-                doublets.append(node)
-
-        return doublets
+        cut_vertices = self._graph.local_cut_vertices()
+        # Skip clones that represent multiple cells
+        return [node for node in cut_vertices if node.n > 1]
 
     def remove_edges(self, edges):
         for node1, node2 in edges:

--- a/src/trex/graph.py
+++ b/src/trex/graph.py
@@ -66,3 +66,18 @@ class Graph:
     def neighbors(self, node):
         """Return a list of all neighbors of a node"""
         return self._nodes[node]
+
+    def induced_subgraph(self, nodes):
+        nodes_set = set(nodes)
+        new_nodes = {
+            node: [neighbor for neighbor in self._nodes[node] if neighbor in nodes_set]
+            for node in nodes
+        }
+        subgraph = Graph([])
+        subgraph._nodes = new_nodes
+
+        return subgraph
+
+    def count_edges(self) -> int:
+        """Return number of edges"""
+        return sum(len(neighbors) for neighbors in self._nodes.values()) // 2

--- a/src/trex/graph.py
+++ b/src/trex/graph.py
@@ -81,3 +81,19 @@ class Graph:
     def count_edges(self) -> int:
         """Return number of edges"""
         return sum(len(neighbors) for neighbors in self._nodes.values()) // 2
+
+    def local_cut_vertices(self):
+        """
+        Return all vertices that, when removed, would lead to their neighborhood being split
+        into two or more connected components.
+        """
+        vertices = []
+        for node in self.nodes():
+            neighbors = self.neighbors(node)
+            if len(neighbors) < 2:
+                continue
+            subgraph = self.induced_subgraph(neighbors)
+            if len(subgraph.connected_components()) > 1:
+                vertices.append(node)
+
+        return vertices

--- a/src/trex/graph.py
+++ b/src/trex/graph.py
@@ -18,6 +18,11 @@ class Graph:
         self._nodes[node1].remove(node2)
         self._nodes[node2].remove(node1)
 
+    def remove_node(self, node):
+        for neighbor in list(self._nodes[node]):
+            self._nodes[neighbor] = [n for n in self._nodes[neighbor] if n != node]
+        del self._nodes[node]
+
     def connected_components(self):
         """Return a list of connected components."""
         visited = set()

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ samtools --version > /dev/null
 pytest tests
 
 set -x
-trex run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
+trex run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
 diff -ur -xdata.loom -xlog.txt -xentries.bam tests/expected trex_run
 
 diff -u <(samtools view -h --no-PG tests/expected/entries.bam) <(samtools view -h --no-PG trex_run/entries.bam) | head -n 10

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ samtools --version > /dev/null
 
 pytest tests
 
+set -x
 trex run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
 diff -ur -xdata.loom -xlog.txt -xentries.bam tests/expected trex_run
 

--- a/tests/expected/log.txt
+++ b/tests/expected/log.txt
@@ -1,5 +1,5 @@
 Trex 0.4.dev220+g35d3306
-Command line arguments: run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
+Command line arguments: run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
 Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
 Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
 Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)
@@ -10,8 +10,6 @@ Found 53 single-read cloneIDs
 697 filtered cells remain
 Writing UMI matrix
 Removing 0 bridges from the graph
-Removing 0 doublets from the graph (first round)
-Removing 0 doublets from the graph (second round)
 Detected 4 clones
 Clone size histogram
  size count

--- a/tests/expected/log.txt
+++ b/tests/expected/log.txt
@@ -10,6 +10,8 @@ Found 53 single-read cloneIDs
 697 filtered cells remain
 Writing UMI matrix
 Removing 0 bridges from the graph
+Removing 0 doublets from the graph (first round)
+Removing 0 doublets from the graph (second round)
 Detected 4 clones
 Clone size histogram
  size count

--- a/tests/expected_per_cell/log.txt
+++ b/tests/expected_per_cell/log.txt
@@ -10,6 +10,7 @@ Found 103 single-read cloneIDs
 697 filtered cells remain
 Removing 0 bridges from the graph
 Removing 0 doublets from the graph (first round)
+Removing 0 bridges from the graph (second round)
 Removing 0 doublets from the graph (second round)
 Detected 11 clones
 Clone size histogram

--- a/tests/expected_per_cell/log.txt
+++ b/tests/expected_per_cell/log.txt
@@ -9,6 +9,8 @@ Detected 1835 cells
 Found 103 single-read cloneIDs
 697 filtered cells remain
 Removing 0 bridges from the graph
+Removing 0 doublets from the graph (first round)
+Removing 0 doublets from the graph (second round)
 Detected 11 clones
 Clone size histogram
  size count

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -68,3 +68,7 @@ def test_count_edges(graph):
     assert graph.count_edges() == 6
 
     assert Graph([]).count_edges() == 0
+
+
+def test_local_cut_vertices(graph):
+    assert graph.local_cut_vertices() == ["B"]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -54,3 +54,17 @@ def test_remove_node(graph):
     assert sorted(graph.nodes()) == list("ACDEFG")
     assert sorted(graph.neighbors("A")) == ["D"]
     assert sorted(graph.edges()) == [("A", "D"), ("F", "G")]
+
+
+def test_induced_subgraph(graph):
+    subgraph = graph.induced_subgraph(["A", "B", "D"])
+    nodes = list(subgraph.nodes())
+    assert sorted(nodes) == ["A", "B", "D"]
+    edges = list(subgraph.edges())
+    assert sorted(edges) == [("A", "B"), ("A", "D"), ("B", "D")]
+
+
+def test_count_edges(graph):
+    assert graph.count_edges() == 6
+
+    assert Graph([]).count_edges() == 0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,56 @@
+from trex.graph import Graph
+
+import pytest
+
+NODES = list("ABCDEFG")
+
+
+@pytest.fixture
+def graph():
+    graph = Graph(NODES)
+    #
+    # (A) -- (B) -- (C)
+    #  |    /  \
+    #  |  /     \
+    # (D)       (E)
+    #
+    # (F) -- (G)
+    #
+    for edge in ["AB", "BC", "AD", "DB", "BE", "FG"]:
+        graph.add_edge(edge[0], edge[1])
+    return graph
+
+
+def test_nodes(graph):
+    assert graph.nodes() == NODES
+
+
+def test_edges(graph):
+    edges = list(graph.edges())
+    assert sorted(edges) == [("A", "B"), ("A", "D"), ("B", "C"), ("B", "D"), ("B", "E"), ("F", "G")]
+
+
+def test_neighbors(graph):
+    neighbors = graph.neighbors("B")
+    assert sorted(neighbors) == ["A", "C", "D", "E"]
+
+
+def test_remove_edge(graph):
+    graph.remove_edge("C", "B")
+    assert sorted(graph.neighbors("B")) == ["A", "D", "E"]
+
+
+def test_connected_components(graph):
+    components = graph.connected_components()
+    assert len(components) == 2
+    nodes1 = components[0].nodes()
+    nodes2 = components[1].nodes()
+    assert sorted(nodes1) == list("ABCDE")
+    assert sorted(nodes2) == list("FG")
+
+
+def test_remove_node(graph):
+    graph.remove_node("B")
+    assert sorted(graph.nodes()) == list("ACDEFG")
+    assert sorted(graph.neighbors("A")) == ["D"]
+    assert sorted(graph.edges()) == [("A", "D"), ("F", "G")]


### PR DESCRIPTION
Closes #30

This adds a doublet detection and removal step to TREX.

I deviated from my suggestion in #30, which would be to search for *cut vertices* (those vertices that, if removed, would lead to the graph being split into two or more connected components). Instead, to decide whether a node is a doublet, I check whether removing the node makes its immediate neighbors lose connection (the rest of the graph is ignored). This was easier to implement and also takes care of cases where there are multiple doublets arranged "in a circle". These doublets would be missed with the "cut vertex" definition.

For whatever reason, results look better when a *second* round of doublet detection is run, so this is what the code does now.

Also, doublet detection ~~is enabled unconditionally because bridge detection is also always enabled.~~ can be disabled with `--keep-doublets`.

## To Do

* [x] Test this and report whether it gives better results (@acorbat?)
* [x] Fix an assertion: `assert len(cells) == number_of_cells_in_clones`
* [x] Save the list of detected doublets to a file
* [x] Add a changelog entry
* [x] Decide whether doublet detection should be always on, opt-in or opt-out
