### PR TITLE
Ensure samtools is installed for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Install samtools
+      run: sudo apt-get install samtools
     - name: Install
       run: |
         python -m pip install --upgrade pip pytest

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -euo pipefail
+
+# Ensure it is installed
+samtools --version > /dev/null
+
 pytest tests
+
 trex run10x --delete --loom --umi-matrix -s 695 -e 724 tests/data/
 diff -ur -xdata.loom -xlog.txt -xentries.bam tests/expected trex_run
+
 diff -u <(samtools view -h --no-PG tests/expected/entries.bam) <(samtools view -h --no-PG trex_run/entries.bam) | head -n 10
 diff -u <(sed 1d tests/expected/log.txt) <(sed 1d trex_run/log.txt)
 


### PR DESCRIPTION
One of the tests was not actually testing anything because `samtools` was not installed and the test failed silently. This PR 1) installs samtools and 2) adds a test that checks whether samtools is installed so that this does not happen again.

(Background: `set -e` in a bash script should make subsequent commands fail, but this does not apply to commands within `<( ... )`.)