### PR TITLE
Improve startup time by not importing all modules all the time 

### DIFF
--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -57,14 +57,6 @@ def make_output_dir(path, delete_if_exists):
 def add_common_arguments(parser, smartseq: bool):
     """Add arguments to an ArgumentParser common to both run10x and smartseq2/3"""
 
-    parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument(
-        "--debug",
-        default=False,
-        action="store_true",
-        help="Print some extra debugging messages",
-    )
-
     input_group = parser.add_argument_group("Input")
 
     input_group.add_argument(

--- a/src/trex/cli/__init__.py
+++ b/src/trex/cli/__init__.py
@@ -3,14 +3,25 @@ from pathlib import Path
 import shutil
 from types import SimpleNamespace
 
-from .. import __version__
-from trex.utils import NiceFormatter
-
 logger = logging.getLogger(__name__)
 
 
 class CommandLineError(Exception):
     pass
+
+
+class NiceFormatter(logging.Formatter):
+    """
+    Do not prefix "INFO:" to info-level log messages (but do it for all other
+    levels).
+
+    Based on http://stackoverflow.com/a/9218261/715090 .
+    """
+
+    def format(self, record):
+        if record.levelno != logging.INFO:
+            record.msg = "{}: {}".format(record.levelname, record.msg)
+        return super().format(record)
 
 
 def setup_logging(debug: bool) -> None:

--- a/src/trex/cli/qc.py
+++ b/src/trex/cli/qc.py
@@ -32,7 +32,7 @@ from ..quality_control import (
     plot_discrete_histogram,
     plot_jaccard_matrix,
 )
-from . import CommandLineError, add_file_logging, setup_logging
+from . import CommandLineError, add_file_logging
 
 logger = logging.getLogger(__name__)
 
@@ -595,8 +595,6 @@ def make_qc_report(
 
 
 def main(args):
-    setup_logging(debug=args.debug)
-
     for output_dir in args.path:
         if not output_dir.exists():
             raise CommandLineError(f"Directory '{output_dir}' does not exist")

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -10,7 +10,6 @@ from typing import List, Dict, Iterable
 import pandas as pd
 
 from . import (
-    setup_logging,
     CommandLineError,
     add_file_logging,
     make_output_dir,
@@ -38,8 +37,6 @@ logger = logging.getLogger(__name__)
 
 
 def main(args):
-    setup_logging(debug=args.debug)
-
     output_dir = args.output
     try:
         make_output_dir(output_dir, args.delete)

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -9,7 +9,7 @@ from typing import List, Iterable
 
 import trex.cli
 from .run10x import read_allowed_cellids, correct_clone_ids
-from . import setup_logging, CommandLineError, add_file_logging, make_output_dir
+from . import CommandLineError, add_file_logging, make_output_dir
 from .. import __version__
 from ..writers import write_count_matrix, write_cells, write_reads_or_molecules
 from ..clone import CloneGraph
@@ -25,8 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 def main(args):
-    setup_logging(debug=args.debug)
-
     output_dir = args.output
     try:
         make_output_dir(output_dir, args.delete)

--- a/src/trex/cli/smartseq3.py
+++ b/src/trex/cli/smartseq3.py
@@ -10,7 +10,6 @@ from typing import List, Dict, Iterable
 
 from .run10x import read_allowed_cellids, correct_clone_ids
 from . import (
-    setup_logging,
     CommandLineError,
     add_file_logging,
     make_output_dir,
@@ -35,8 +34,6 @@ logger = logging.getLogger(__name__)
 
 
 def main(args):
-    setup_logging(debug=args.debug)
-
     output_dir = args.output
     try:
         make_output_dir(output_dir, args.delete)

--- a/src/trex/utils.py
+++ b/src/trex/utils.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List
 
 import pandas as pd

--- a/src/trex/utils.py
+++ b/src/trex/utils.py
@@ -7,20 +7,6 @@ from .cell import Cell
 from .molecule import Molecule
 
 
-class NiceFormatter(logging.Formatter):
-    """
-    Do not prefix "INFO:" to info-level log messages (but do it for all other
-    levels).
-
-    Based on http://stackoverflow.com/a/9218261/715090 .
-    """
-
-    def format(self, record):
-        if record.levelno != logging.INFO:
-            record.msg = "{}: {}".format(record.levelname, record.msg)
-        return super().format(record)
-
-
 def molecule_list_to_dataframe(molecules: List[Molecule]) -> pd.DataFrame:
     """Convert list of Molecules to pandas DataFrame"""
     molecule_dict = {"cell_id": [], "umi": [], "clone_id": [], "read_count": []}


### PR DESCRIPTION
This is taken from https://github.com/whatshap/whatshap/commit/8656917f36766c4b247db3ac83a3f4744963fc93

When building the argument parser, we previously imported all the cli modules, which is quite slow. However, the only thing we need from *all* modules is their docstrings (which we use for displaying help). Here, we use the ast module to parse the .py files, which allows us to obtain the docstring much quicker.

Before:
```
$ time trex --version
trex 0.4.dev231+g916bc10

real    0m2.391s
user    0m2.374s
sys     0m0.762s
```
After:
```
$ time trex --version
0.4.dev231+g916bc10

real    0m0.060s
user    0m0.051s
sys     0m0.008s
```
This also speeds up running the tests by a couple of seconds.