### PR TITLE
Convert test.sh tests to pytest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,4 @@ jobs:
         python -m pip install --upgrade pip pytest
         python -m pip install .
     - name: Test
-      run: |
-        ./test.sh
+      run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ trex = "trex.__main__:main"
 [tool.setuptools_scm]
 write_to = "src/trex/_version.py"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+xfail_strict = true
+
 [tool.ruff]
 select = ["E", "F", "W"]
 ignore = ["E501"]  # line too long

--- a/src/trex/bam.py
+++ b/src/trex/bam.py
@@ -101,7 +101,6 @@ def read_bam(
                 reads.append(Read(cell_id=cell_id, umi=umi, clone_id=clone_id))
                 # Write the passing alignments to a separate file
                 out_bam.write(read)
-            print("The amount of reads with no_umi: ", no_umi)
 
     if require_umis:
         logger.info(

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -7,7 +7,7 @@ import logging
 import dataclasses
 from pathlib import Path
 from collections import Counter, defaultdict
-from typing import List, Dict, Iterable, DefaultDict
+from typing import List, Dict, Iterable, Optional, DefaultDict, Union
 
 import pandas as pd
 
@@ -163,29 +163,30 @@ def add_arguments(parser):
 
 def run_trex(
     output_dir: Path,
-    genome_name: str,
-    allowed_cell_ids: List[str],
-    excluded_clone_ids: List[str],
-    chromosome: str,
-    start: int,
-    end: int,
-    transcriptome_inputs: List[Path],
+    *,
+    transcriptome_inputs: List[Union[Path, str]],
     amplicon_inputs: List[Path],
-    sample_names: List[str],
-    prefix: bool,
-    max_hamming: int,
-    correct_per_cell: bool,
-    min_length: int,
-    jaccard_threshold: float,
-    keep_single_reads: bool,
-    keep_doublets: bool,
-    should_write_umi_matrix: bool,
-    should_run_visium: bool,
-    should_plot: bool,
-    highlight_cell_ids: List[str],
-    should_write_loom: bool,
+    genome_name: Optional[str] = None,
+    allowed_cell_ids: Optional[List[str]] = None,
+    excluded_clone_ids: Optional[List[str]] = None,
+    chromosome: Optional[str] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    sample_names: Optional[List[str]] = None,
+    prefix: bool = False,
+    max_hamming: int = 5,
+    correct_per_cell: bool = False,
+    min_length: int = 20,
+    jaccard_threshold: float = 0.7,
+    keep_single_reads: bool = False,
+    keep_doublets: bool = False,
+    should_write_umi_matrix: bool = False,
+    should_run_visium: bool = False,
+    should_plot: bool = False,
+    highlight_cell_ids: Optional[List[str]] = None,
+    should_write_loom: bool = False,
 ):
-    if len(sample_names) != len(set(sample_names)):
+    if sample_names is not None and len(sample_names) != len(set(sample_names)):
         raise TrexError("The sample names need to be unique")
 
     dataset_reader = DatasetReader(

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -5,7 +5,7 @@ import sys
 import logging
 from pathlib import Path
 from collections import Counter
-from typing import List, Iterable
+from typing import List, Iterable, Optional, Union
 
 import trex.cli
 from .run10x import read_allowed_cellids, correct_clone_ids
@@ -114,24 +114,25 @@ def add_arguments(parser):
 
 def run_smartseq2(
     output_dir: Path,
-    genome_name: str,
-    allowed_cell_ids: List[str],
-    chromosome: str,
-    start: int,
-    end: int,
-    transcriptome_inputs: List[Path],
+    *,
+    transcriptome_inputs: List[Union[Path, str]],
     amplicon_inputs: List[Path],
-    sample_names: List[str],
-    prefix: bool,
-    max_hamming: int,
-    min_length: int,
-    jaccard_threshold: float,
-    readcount_threshold: int,
-    should_write_read_matrix: bool,
-    should_plot: bool,
-    highlight_cell_ids: List[str],
+    genome_name: Optional[str] = None,
+    allowed_cell_ids: Optional[List[str]] = None,
+    chromosome: Optional[str] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    sample_names: Optional[List[str]] = None,
+    prefix: bool = False,
+    max_hamming: int = 5,
+    min_length: int = 20,
+    jaccard_threshold: float = 0.7,
+    readcount_threshold: int = 2,
+    should_write_read_matrix: bool = False,
+    should_plot: bool = False,
+    highlight_cell_ids: Optional[List[str]] = None,
 ):
-    if len(sample_names) != len(set(sample_names)):
+    if sample_names is not None and len(sample_names) != len(set(sample_names)):
         raise TrexError("The sample names need to be unique")
 
     dataset_reader = DatasetReader(

--- a/src/trex/cli/smartseq3.py
+++ b/src/trex/cli/smartseq3.py
@@ -95,7 +95,7 @@ def main(args):
             keep_single_reads=args.keep_single_reads,
             should_write_umi_matrix=args.umi_matrix,
             should_plot=args.plot,
-            highlight_cell_ids=highlight_cell_ids
+            highlight_cell_ids=highlight_cell_ids,
         )
     except TrexError as e:
         raise CommandLineError("%s", e)
@@ -103,7 +103,6 @@ def main(args):
 
 def add_arguments(parser):
     groups = add_common_arguments(parser, smartseq=True)
-
 
     groups.filter.add_argument(
         "--keep-single-reads",

--- a/src/trex/cli/smartseq3.py
+++ b/src/trex/cli/smartseq3.py
@@ -5,8 +5,7 @@ import sys
 import logging
 from pathlib import Path
 from collections import Counter
-from typing import List, Dict, Iterable
-
+from typing import List, Dict, Iterable, Optional
 
 from .run10x import read_allowed_cellids, correct_clone_ids
 from . import (
@@ -122,24 +121,25 @@ def add_arguments(parser):
 
 def run_smartseq3(
     output_dir: Path,
-    genome_name: str,
-    allowed_cell_ids: List[str],
-    chromosome: str,
-    start: int,
-    end: int,
+    *,
     transcriptome_inputs: List[Path],
     amplicon_inputs: List[Path],
-    sample_names: List[str],
-    prefix: bool,
-    max_hamming: int,
-    min_length: int,
-    jaccard_threshold: float,
-    keep_single_reads: bool,
-    should_write_umi_matrix: bool,
-    should_plot: bool,
-    highlight_cell_ids: List[str],
+    genome_name: Optional[str] = None,
+    allowed_cell_ids: Optional[List[str]] = None,
+    chromosome: Optional[str] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    sample_names: Optional[List[str]] = None,
+    prefix: bool = False,
+    max_hamming: int = 5,
+    min_length: int = 20,
+    jaccard_threshold: float = 0.7,
+    keep_single_reads: bool = False,
+    should_write_umi_matrix: bool = False,
+    should_plot: bool = False,
+    highlight_cell_ids: Optional[List[str]] = None,
 ):
-    if len(sample_names) != len(set(sample_names)):
+    if sample_names is not None and len(sample_names) != len(set(sample_names)):
         raise TrexError("The sample names need to be unique")
 
     dataset_reader = DatasetReader(

--- a/src/trex/dataset.py
+++ b/src/trex/dataset.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from itertools import zip_longest
 import logging
+from typing import Optional, List
 
 from .bam import read_bam
 from .cellranger import make_cellranger
@@ -50,13 +51,15 @@ class DatasetReader:
         self,
         transcriptome_inputs,
         amplicon_inputs,
-        names,
-        allowed_cell_ids,
+        names: Optional[List[str]],
+        allowed_cell_ids: Optional[List[str]],
         require_umis=True,
         cell_id_tag="CB",
     ):
         n_transcriptome = len(transcriptome_inputs)
         n_amplicon = len(amplicon_inputs)
+        if names is None:
+            names = [None] * n_transcriptome
         assert n_transcriptome > 0
         assert n_amplicon == 0 or n_amplicon == n_transcriptome
         assert n_transcriptome == len(names)

--- a/test.sh
+++ b/test.sh
@@ -8,9 +8,6 @@ pytest tests
 
 set -x
 
-
-trex qc trex_run
-
 # Ensure --filter-clone-id works
 trex run10x --per-cell --delete -s 695 -e 724 -o trex_filter_clone_id --filter-cloneids tests/data/exclude_list.csv tests/data
 diff -u <(sed 1d tests/expected_filter_clone_id/log.txt) <(sed 1d trex_filter_clone_id/log.txt)

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-# Ensure it is installed
-samtools --version > /dev/null
-
-pytest tests
-
-set -x

--- a/test.sh
+++ b/test.sh
@@ -8,8 +8,6 @@ pytest tests
 
 set -x
 
-trex smartseq3 --delete --output trex_smartseq3_run --umi-matrix -s 2330 -e 2359 tests/data/smartseq3_test.bam
-diff -u <(sed 1d tests/expected_smartseq3/log.txt) <(sed 1d trex_smartseq3_run/log.txt)
 
 trex qc trex_run
 

--- a/test.sh
+++ b/test.sh
@@ -8,9 +8,6 @@ pytest tests
 
 set -x
 
-trex smartseq2 --delete --chr EGFP-30N --output trex_smartseq2_run --start 2330 --end 2359 --read-matrix --readcount-threshold 1 tests/data/smartseq2_test.bam
-diff -u <(sed 1d tests/expected_smartseq2/log.txt) <(sed 1d trex_smartseq2_run/log.txt)
-
 trex smartseq3 --delete --output trex_smartseq3_run --umi-matrix -s 2330 -e 2359 tests/data/smartseq3_test.bam
 diff -u <(sed 1d tests/expected_smartseq3/log.txt) <(sed 1d trex_smartseq3_run/log.txt)
 

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,3 @@ samtools --version > /dev/null
 pytest tests
 
 set -x
-
-# Ensure --filter-clone-id works
-trex run10x --per-cell --delete -s 695 -e 724 -o trex_filter_clone_id --filter-cloneids tests/data/exclude_list.csv tests/data
-diff -u <(sed 1d tests/expected_filter_clone_id/log.txt) <(sed 1d trex_filter_clone_id/log.txt)

--- a/test.sh
+++ b/test.sh
@@ -7,11 +7,6 @@ samtools --version > /dev/null
 pytest tests
 
 set -x
-trex run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
-diff -ur -xdata.loom -xlog.txt -xentries.bam tests/expected trex_run
-
-diff -u <(samtools view -h --no-PG tests/expected/entries.bam) <(samtools view -h --no-PG trex_run/entries.bam) | head -n 10
-diff -u <(sed 1d tests/expected/log.txt) <(sed 1d trex_run/log.txt)
 
 trex smartseq2 --delete --chr EGFP-30N --output trex_smartseq2_run --start 2330 --end 2359 --read-matrix --readcount-threshold 1 tests/data/smartseq2_test.bam
 diff -u <(sed 1d tests/expected_smartseq2/log.txt) <(sed 1d trex_smartseq2_run/log.txt)

--- a/test.sh
+++ b/test.sh
@@ -11,10 +11,6 @@ set -x
 
 trex qc trex_run
 
-# Ensure --per-cell works
-trex run10x --per-cell --delete -s 695 -e 724 -o trex_per_cell tests/data
-diff -u <(sed 1d tests/expected_per_cell/log.txt) <(sed 1d trex_per_cell/log.txt)
-
 # Ensure --filter-clone-id works
 trex run10x --per-cell --delete -s 695 -e 724 -o trex_filter_clone_id --filter-cloneids tests/data/exclude_list.csv tests/data
 diff -u <(sed 1d tests/expected_filter_clone_id/log.txt) <(sed 1d trex_filter_clone_id/log.txt)

--- a/tests/expected/log.txt
+++ b/tests/expected/log.txt
@@ -1,5 +1,3 @@
-Trex 0.4.dev253+g7d94d1c.d20231017
-Command line arguments: run10x --delete --keep-doublets --loom --umi-matrix -s 695 -e 724 tests/data/
 Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
 Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
 Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)

--- a/tests/expected_filter_clone_id/log.txt
+++ b/tests/expected_filter_clone_id/log.txt
@@ -1,6 +1,3 @@
-Trex 0.4.dev285+g14f4e4a.d20231020
-Command line arguments: run10x --per-cell --delete -s 695 -e 724 -o trex_filter_clone_id --filter-cloneids tests/data/exclude_list.csv tests/data
-2 CloneIDs will be ignored during the analysis
 Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
 Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
 Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)

--- a/tests/expected_per_cell/log.txt
+++ b/tests/expected_per_cell/log.txt
@@ -1,5 +1,3 @@
-Trex 0.4.dev253+g7d94d1c.d20231017
-Command line arguments: run10x --per-cell --delete -s 695 -e 724 -o trex_per_cell tests/data
 Reading cloneIDs from chrTomato-N:695-724 in tests/data/outs/possorted_genome_bam.bam
 Found 3857 reads with usable cloneIDs and UMIs. Skipped 1692 without cell id, 3 without UMI.
 Read 3857 reads containing (parts of) the cloneID (2703 full cloneIDs, 71 unique)

--- a/tests/expected_smartseq2/log.txt
+++ b/tests/expected_smartseq2/log.txt
@@ -1,5 +1,3 @@
-Trex 0.4.dev115+gb2242a8
-Command line arguments: smartseq2 --delete --chr EGFP-30N --output trex_smartseq2_run --start 2330 --end 2359 --read-matrix --readcount-threshold 1 tests/data/smartseq2_test.bam
 Reading cloneIDs from EGFP-30N:2330-2359 in tests/data/smartseq2_test.bam
 Found 286 reads with usable cloneIDs. Skipped 0 without cell id
 Read 286 reads containing (parts of) the cloneID (135 full cloneIDs, 115 unique)

--- a/tests/expected_smartseq3/log.txt
+++ b/tests/expected_smartseq3/log.txt
@@ -1,5 +1,3 @@
-Trex 0.4.dev220+g35d3306
-Command line arguments: smartseq3 --delete --output trex_smartseq3_run --umi-matrix -s 2330 -e 2359 tests/data/smartseq3_test.bam
 Reading cloneIDs from EGFP-30N:2330-2359 in tests/data/smartseq3_test.bam
 Found 9631 reads with usable cloneIDs and UMIs. Skipped 0 without cell id, 24435 without UMI.
 Read 9631 reads containing (parts of) the cloneID (4593 full cloneIDs, 943 unique)

--- a/tests/test_run10x.py
+++ b/tests/test_run10x.py
@@ -1,0 +1,42 @@
+import logging
+import subprocess
+
+from trex.cli import add_file_logging
+from trex.cli.run10x import run_trex
+
+
+def diff(expected, actual, ignore=None, recursive=False):
+    args = ["diff", "-u"]
+    if recursive:
+        args.append("-r")
+    if ignore is not None:
+        args += [f"-x{name}" for name in ignore]
+    subprocess.run(args + [expected, actual]).check_returncode()
+
+
+def bam_diff(expected_bam, actual_bam, tmp_path):
+    expected_sam = tmp_path / "expected.sam"
+    actual_sam = tmp_path / "actual.sam"
+    with open(expected_sam, "w") as expected, open(actual_sam, "w") as actual:
+        subprocess.run(["samtools", "view", "--no-PG", "-h", expected_bam], stdout=expected)
+        subprocess.run(["samtools", "view", "--no-PG", "-h", actual_bam], stdout=actual)
+    diff(expected_sam, actual_sam)
+
+
+def test_run_trex(tmp_path):
+    add_file_logging(tmp_path / "log.txt")
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    run_trex(
+        tmp_path,
+        keep_doublets=True,
+        should_write_loom=True,
+        should_write_umi_matrix=True,
+        start=694,
+        end=724,
+        transcriptome_inputs=["tests/data/"],
+        amplicon_inputs=[],
+    )
+    diff("tests/expected", tmp_path, ignore=["data.loom", "entries.bam"], recursive=True)
+    bam_diff("tests/expected/entries.bam", tmp_path / "entries.bam", tmp_path)

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -33,16 +33,33 @@ def test_run_trex(tmp_path):
 
     run_trex(
         tmp_path,
+        transcriptome_inputs=["tests/data/"],
+        amplicon_inputs=[],
+        start=694,
+        end=724,
         keep_doublets=True,
         should_write_loom=True,
         should_write_umi_matrix=True,
-        start=694,
-        end=724,
-        transcriptome_inputs=["tests/data/"],
-        amplicon_inputs=[],
     )
     diff("tests/expected", tmp_path, ignore=["data.loom", "entries.bam"], recursive=True)
     bam_diff("tests/expected/entries.bam", tmp_path / "entries.bam", tmp_path)
+
+
+def test_run_trex_per_cell(tmp_path):
+    # Ensure --per-cell works
+    add_file_logging(tmp_path / "log.txt")
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    run_trex(
+        tmp_path,
+        transcriptome_inputs=["tests/data/"],
+        amplicon_inputs=[],
+        start=694,
+        end=724,
+        correct_per_cell=True,
+    )
+    diff("tests/expected_per_cell/log.txt", tmp_path / "log.txt")
 
 
 def test_run_smartseq2(tmp_path):
@@ -52,13 +69,13 @@ def test_run_smartseq2(tmp_path):
 
     run_smartseq2(
         tmp_path,
+        transcriptome_inputs=[Path("tests/data/smartseq2_test.bam")],
+        amplicon_inputs=[],
         start=2329,
         end=2359,
         should_write_read_matrix=True,
         readcount_threshold=1,
         chromosome="EGFP-30N",
-        transcriptome_inputs=[Path("tests/data/smartseq2_test.bam")],
-        amplicon_inputs=[],
     )
     diff("tests/expected_smartseq2/log.txt", tmp_path / "log.txt")
 
@@ -70,11 +87,11 @@ def test_run_smartseq3(tmp_path):
 
     run_smartseq3(
         tmp_path,
+        transcriptome_inputs=[Path("tests/data/smartseq3_test.bam")],
+        amplicon_inputs=[],
         start=2329,
         end=2359,
         chromosome="EGFP-30N",
-        transcriptome_inputs=[Path("tests/data/smartseq3_test.bam")],
-        amplicon_inputs=[],
         should_write_umi_matrix=True,
     )
     diff("tests/expected_smartseq3/log.txt", tmp_path / "log.txt")

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -1,8 +1,10 @@
 import logging
 import subprocess
 from pathlib import Path
+from shutil import copytree
 
 from trex.cli import add_file_logging
+from trex.cli.qc import make_qc_report
 from trex.cli.run10x import run_trex
 from trex.cli.smartseq2 import run_smartseq2
 from trex.cli.smartseq3 import run_smartseq3
@@ -96,3 +98,19 @@ def test_run_smartseq3(tmp_path):
     )
     diff("tests/expected_smartseq3/log.txt", tmp_path / "log.txt")
     assert tmp_path.joinpath("umi_count_matrix.csv").exists()
+
+
+def test_qc(tmp_path):
+    add_file_logging(tmp_path / "log.txt")
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    pdf_path = tmp_path / "quality_report.pdf"
+
+    copytree("tests/expected", tmp_path / "trexrun")
+    make_qc_report(
+        tmp_path / "trexrun",
+        pdf_path,
+        plot_jaccard=True,
+        plot_hamming=True,
+    )
+    assert pdf_path.exists()

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -1,8 +1,10 @@
 import logging
 import subprocess
+from pathlib import Path
 
 from trex.cli import add_file_logging
 from trex.cli.run10x import run_trex
+from trex.cli.smartseq2 import run_smartseq2
 
 
 def diff(expected, actual, ignore=None, recursive=False):
@@ -40,3 +42,21 @@ def test_run_trex(tmp_path):
     )
     diff("tests/expected", tmp_path, ignore=["data.loom", "entries.bam"], recursive=True)
     bam_diff("tests/expected/entries.bam", tmp_path / "entries.bam", tmp_path)
+
+
+def test_run_smartseq2(tmp_path):
+    add_file_logging(tmp_path / "log.txt")
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    run_smartseq2(
+        tmp_path,
+        start=2329,
+        end=2359,
+        should_write_read_matrix=True,
+        readcount_threshold=1,
+        chromosome="EGFP-30N",
+        transcriptome_inputs=[Path("tests/data/smartseq2_test.bam")],
+        amplicon_inputs=[],
+    )
+    diff("tests/expected_smartseq2/log.txt", tmp_path / "log.txt")

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from trex.cli import add_file_logging
 from trex.cli.run10x import run_trex
 from trex.cli.smartseq2 import run_smartseq2
+from trex.cli.smartseq3 import run_smartseq3
 
 
 def diff(expected, actual, ignore=None, recursive=False):
@@ -60,3 +61,21 @@ def test_run_smartseq2(tmp_path):
         amplicon_inputs=[],
     )
     diff("tests/expected_smartseq2/log.txt", tmp_path / "log.txt")
+
+
+def test_run_smartseq3(tmp_path):
+    add_file_logging(tmp_path / "log.txt")
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    run_smartseq3(
+        tmp_path,
+        start=2329,
+        end=2359,
+        chromosome="EGFP-30N",
+        transcriptome_inputs=[Path("tests/data/smartseq3_test.bam")],
+        amplicon_inputs=[],
+        should_write_umi_matrix=True,
+    )
+    diff("tests/expected_smartseq3/log.txt", tmp_path / "log.txt")
+    assert tmp_path.joinpath("umi_count_matrix.csv").exists()


### PR DESCRIPTION
This is a first step towards fully eliminating the `test.sh` shell script. pytest is a nice testing framework with many helpful features that we don’t get in the shell script. For example:
- When one test fails, the others are still run.
- Tests have names, and we see the names of the failed tests..
- We can use `pytest --lf` to run only the last failed tests.
- The logging output is cleaner when the tests succeed (just one dot for each passing test).
- Moving shell tests into pytest makes things more consistent.
- We can use pytest’s `tmp_path` fixture: Output is created in a temporary location and automatically deleted when the test passes. It is kept if the test fails, and can the be inspected.
- We force ourselves to use our own "API" (here, the `run_trex` function), which is good because we see directly whether using it has problems (I already changed something).

The code is a bit longer, but it’s worth it to me.