### PR TITLE
Reformat code with Black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on: [push]
 
 jobs:
+  lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+        toxenv: [black]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: python -m pip install tox
+    - name: Run tox ${{ matrix.toxenv }}
+      run: tox -e ${{ matrix.toxenv }}
+
   build:
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
   rev: v0.0.292
   hooks:
     - id: ruff
+- repo: https://github.com/psf/black
+  rev: 23.10.1
+  hooks:
+    - id: black

--- a/src/trex/__main__.py
+++ b/src/trex/__main__.py
@@ -34,7 +34,9 @@ def main(arguments=None):
     subcommand_name = get_subcommand_name(arguments)
     module = importlib.import_module("." + subcommand_name, cli_package.__name__)
     parser = HelpfulArgumentParser(description=__doc__, prog="trex")
-    parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + __version__
+    )
     parser.add_argument(
         "--debug",
         default=False,

--- a/src/trex/bam.py
+++ b/src/trex/bam.py
@@ -67,7 +67,7 @@ def read_bam(
                 has_umi = read.has_tag("UB")
                 if has_umi:
                     if len(read.get_tag("UB")) == 0:
-                        no_umi +=1
+                        no_umi += 1
                 if not has_cell_id:
                     no_cell_id += 1
                 if not has_umi:
@@ -82,7 +82,7 @@ def read_bam(
                     continue
 
                 umi = read.get_tag("UB")
-                if umi == '':
+                if umi == "":
                     umi = None
                 if cell_id_tag == "CB":
                     if not cell_id.endswith("-1"):
@@ -96,7 +96,7 @@ def read_bam(
                     # Read does not cover the cloneID
                     continue
                 if require_umis and not umi:
-                    #Read does not have a umi
+                    # Read does not have a umi
                     continue
                 reads.append(Read(cell_id=cell_id, umi=umi, clone_id=clone_id))
                 # Write the passing alignments to a separate file

--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -220,7 +220,9 @@ def run_trex(
 
     molecules = [m for m in molecules if not is_low_complexity(m.clone_id)]
     logger.info(f"{len(molecules)} remain after low-complexity filtering")
-    write_reads_or_molecules(output_dir / "molecules_filtered.txt", molecules, sort=False)
+    write_reads_or_molecules(
+        output_dir / "molecules_filtered.txt", molecules, sort=False
+    )
 
     if correct_per_cell:
         corrected_molecules = correct_clone_ids_per_cell(

--- a/src/trex/cli/smartseq2.py
+++ b/src/trex/cli/smartseq2.py
@@ -108,7 +108,7 @@ def add_arguments(parser):
         default=False,
         action="store_true",
         help="Create a read count matrix 'read_count_matrix.csv' "
-             "with cells as columns and cloneIDs as rows",
+        "with cells as columns and cloneIDs as rows",
     )
 
 

--- a/src/trex/cli/smartseq3.py
+++ b/src/trex/cli/smartseq3.py
@@ -15,11 +15,7 @@ from . import (
     add_common_arguments,
 )
 from .. import __version__
-from ..writers import (
-    write_count_matrix,
-    write_cells,
-    write_reads_or_molecules
-)
+from ..writers import write_count_matrix, write_cells, write_reads_or_molecules
 from ..clone import CloneGraph
 from ..molecule import Molecule, compute_molecules
 from ..cell import Cell, compute_cells
@@ -239,6 +235,7 @@ def run_smartseq3(
     number_of_cells_in_clones = sum(k * v for k, v in clone_sizes.items())
     logger.debug("No. of cells in clones: %d", number_of_cells_in_clones)
     assert len(cells) == number_of_cells_in_clones
+
 
 def filter_cells(
     cells: Iterable[Cell],

--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -158,8 +158,12 @@ class CloneGraph:
         subprocess.run(["sfdp", "-Tpdf", "-o", pdf_path, graphviz_path], check=True)
 
     def dot(self, highlight_cell_ids=None, highlight_doublets=None) -> str:
-        highlight_cell_ids = set(highlight_cell_ids) if highlight_cell_ids is not None else set()
-        highlight_doublets = set(highlight_doublets) if highlight_doublets is not None else set()
+        highlight_cell_ids = (
+            set(highlight_cell_ids) if highlight_cell_ids is not None else set()
+        )
+        highlight_doublets = (
+            set(highlight_doublets) if highlight_doublets is not None else set()
+        )
         max_width = 10
         edge_scaling = (max_width - 1) / math.log(
             max(

--- a/src/trex/molecule.py
+++ b/src/trex/molecule.py
@@ -71,7 +71,7 @@ def compute_consensus(sequences: Sequence[str]) -> str:
     matrix = np.zeros([length, 6], dtype="float16")
     for sequence in sequences:
         align = np.zeros([length, 6], dtype="float16")
-        for (i, ch) in enumerate(sequence):
+        for i, ch in enumerate(sequence):
             # turns each base into a number and position in numpy array
             if ch == "A":
                 align[i, 0] = 1

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -10,11 +10,15 @@ def parse_cluster(s):
 
 
 def test_parse_cluster():
-    assert parse_cluster(
-        """
+    assert (
+        parse_cluster(
+            """
         TGGGTCGTTATAA 1
         AGGGTCGTTATAA 1
-        """) == ["TGGGTCGTTATAA", "AGGGTCGTTATAA"]
+        """
+        )
+        == ["TGGGTCGTTATAA", "AGGGTCGTTATAA"]
+    )
 
 
 def test_cluster_1():
@@ -30,7 +34,10 @@ def test_cluster_1():
         -------------------GGTCGTTATAA 1
         """
     )
-    clusters = cluster_sequences(sequences, is_similar=lambda s, t: is_similar(s, t, min_overlap=10, max_hamming=5))
+    clusters = cluster_sequences(
+        sequences,
+        is_similar=lambda s, t: is_similar(s, t, min_overlap=10, max_hamming=5),
+    )
 
     assert len(clusters) == 1
     assert sorted(clusters[0]) == sorted(sequences)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -27,7 +27,14 @@ def test_nodes(graph):
 
 def test_edges(graph):
     edges = list(graph.edges())
-    assert sorted(edges) == [("A", "B"), ("A", "D"), ("B", "C"), ("B", "D"), ("B", "E"), ("F", "G")]
+    assert sorted(edges) == [
+        ("A", "B"),
+        ("A", "D"),
+        ("B", "C"),
+        ("B", "D"),
+        ("B", "E"),
+        ("F", "G"),
+    ]
 
 
 def test_neighbors(graph):

--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -13,32 +13,33 @@ def test_is_similar_unequal_length_raises():
     error.match("same length")
 
 
-@pytest.mark.parametrize("s,t,similar", [
-    ("AAAAAAAAAA", "AAAAAAAAAA", True),
-    ("CAAAAAAAAA", "AAAAAAAAAA", True),
-    ("CCAAAAAAAA", "AAAAAAAAAA", False),
-
-    ("", "", False),  # too little overlap
-    ("ACGT", "ACGT", False),  # too little overlap
-    ("TACGT", "TACGT", True),
-    ("TACGT", "TATGT", True),
-    ("TACGT", "TTTGT", False),  # too many differences
-
-    ("------ACGT", "------ACGT", False),  # too little overlap
-    ("-----TACGT", "-----TACGT", True),
-    ("-----TACGT", "-----TATGT", True),
-    ("-----TACGT", "GGGGGTATGT", True),
-    ("TACGT-----", "TATGT-----", True),
-    ("TACGT-----", "TATGTGGGGG", True),
-    ("TAC-----GT", "TAT-----GT", True),
-    ("TAC-----GT", "TATGGGGGGT", True),
-    ("--TAC---GT--", "--TATGGGGT--", True),
-    ("--TAC---GTGG", "--TATGGGGT--", True),
-    ("--TAC---TTGG", "--TATGGGGT--", False),
-    ("GGTAC---GT--", "GGTATGGGGT--", True),
-    ("---00TACGT", "GGGGGTATGT", True),  # Mixing 0 and -
-    ("---00TACGT", "GGGGGTATGA", False),
-])
+@pytest.mark.parametrize(
+    "s,t,similar",
+    [
+        ("AAAAAAAAAA", "AAAAAAAAAA", True),
+        ("CAAAAAAAAA", "AAAAAAAAAA", True),
+        ("CCAAAAAAAA", "AAAAAAAAAA", False),
+        ("", "", False),  # too little overlap
+        ("ACGT", "ACGT", False),  # too little overlap
+        ("TACGT", "TACGT", True),
+        ("TACGT", "TATGT", True),
+        ("TACGT", "TTTGT", False),  # too many differences
+        ("------ACGT", "------ACGT", False),  # too little overlap
+        ("-----TACGT", "-----TACGT", True),
+        ("-----TACGT", "-----TATGT", True),
+        ("-----TACGT", "GGGGGTATGT", True),
+        ("TACGT-----", "TATGT-----", True),
+        ("TACGT-----", "TATGTGGGGG", True),
+        ("TAC-----GT", "TAT-----GT", True),
+        ("TAC-----GT", "TATGGGGGGT", True),
+        ("--TAC---GT--", "--TATGGGGT--", True),
+        ("--TAC---GTGG", "--TATGGGGT--", True),
+        ("--TAC---TTGG", "--TATGGGGT--", False),
+        ("GGTAC---GT--", "GGTATGGGGT--", True),
+        ("---00TACGT", "GGGGGTATGT", True),  # Mixing 0 and -
+        ("---00TACGT", "GGGGGTATGA", False),
+    ],
+)
 def test_is_similar(s, t, similar):
     min_overlap = 5
     max_hamming = 1
@@ -50,15 +51,18 @@ def test_is_similar(s, t, similar):
     assert is_similar(s, t.replace("-", "0"), min_overlap, max_hamming) == similar
 
 
-@pytest.mark.parametrize("s,strings,similar", [
-    ("AAAAAAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
-    ("TAAAAAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], False),
-    ("TTTTTTTAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
-    ("TTTTTTTAAG", ["AAAAAAAAAA", "TTTTTTTAAA"], False),
-    ("TTTTTT--AA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
-    ("----AAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
-    ("AAAAAAAAAA", ["AAAAAAAAAA"], True),
-    ("AAAAAAAAAA", ["TTTTTTTAAA"], False),
-])
+@pytest.mark.parametrize(
+    "s,strings,similar",
+    [
+        ("AAAAAAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
+        ("TAAAAAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], False),
+        ("TTTTTTTAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
+        ("TTTTTTTAAG", ["AAAAAAAAAA", "TTTTTTTAAA"], False),
+        ("TTTTTT--AA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
+        ("----AAAAAA", ["AAAAAAAAAA", "TTTTTTTAAA"], True),
+        ("AAAAAAAAAA", ["AAAAAAAAAA"], True),
+        ("AAAAAAAAAA", ["TTTTTTTAAA"], False),
+    ],
+)
 def test_is_similar_to_any(s, strings, similar):
     assert is_similar_to_any(s, strings) == similar

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -24,7 +24,9 @@ def bam_diff(expected_bam, actual_bam, tmp_path):
     expected_sam = tmp_path / "expected.sam"
     actual_sam = tmp_path / "actual.sam"
     with open(expected_sam, "w") as expected, open(actual_sam, "w") as actual:
-        subprocess.run(["samtools", "view", "--no-PG", "-h", expected_bam], stdout=expected)
+        subprocess.run(
+            ["samtools", "view", "--no-PG", "-h", expected_bam], stdout=expected
+        )
         subprocess.run(["samtools", "view", "--no-PG", "-h", actual_bam], stdout=actual)
     diff(expected_sam, actual_sam)
 
@@ -44,7 +46,9 @@ def test_run_trex(tmp_path):
         should_write_loom=True,
         should_write_umi_matrix=True,
     )
-    diff("tests/expected", tmp_path, ignore=["data.loom", "entries.bam"], recursive=True)
+    diff(
+        "tests/expected", tmp_path, ignore=["data.loom", "entries.bam"], recursive=True
+    )
     bam_diff("tests/expected/entries.bam", tmp_path / "entries.bam", tmp_path)
 
 
@@ -117,7 +121,10 @@ def test_qc(tmp_path):
     assert pdf_path.exists()
 
 
-EXCLUDED_CLONE_IDS = {"GGTCTCCCTATACCAACAGTATCGTCTCAA", "GGGTTCTGGGATATTACGTTGACTTGAGAG"}
+EXCLUDED_CLONE_IDS = {
+    "GGTCTCCCTATACCAACAGTATCGTCTCAA",
+    "GGGTTCTGGGATATTACGTTGACTTGAGAG",
+}
 
 
 def test_filter_clone_ids(tmp_path):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps = flake8
 commands = flake8 src/ tests/
 
 [testenv:black]
-basepython = python3.8
+basepython = python3.10
 deps = black==22.3.0
 skip_install = true
 commands = black --check src/ tests/


### PR DESCRIPTION
This reformats the code with the [black code formatter](https://black.readthedocs.io/en/stable/), which has become the de-facto standard for automatically formatting Python code. It’s used in many open source projects.

This also adds a pre-commit hook that checks whether the code is correctly formatted at commit time.

Also, a CI check was added that fails if the code is not formatted the way black would do it.