### PR TITLE
Fix plot clone graph bug

### DIFF
--- a/src/trex/clone.py
+++ b/src/trex/clone.py
@@ -165,15 +165,19 @@ class CloneGraph:
             set(highlight_doublets) if highlight_doublets is not None else set()
         )
         max_width = 10
-        edge_scaling = (max_width - 1) / math.log(
-            max(
-                (node1.n * node2.n for node1, node2 in self._graph.edges()),
-                default=math.exp(1),
+        try:
+            edge_scaling = (max_width - 1) / math.log(
+                max(
+                    (node1.n * node2.n for node1, node2 in self._graph.edges()),
+                    default=math.exp(1),
+                )
             )
-        )
-        node_scaling = (max_width - 1) / math.log(
-            max(node.n for node in self._graph.nodes())
-        )
+            node_scaling = (max_width - 1) / math.log(
+                max(node.n for node in self._graph.nodes())
+            )
+        except ZeroDivisionError:
+            edge_scaling = max_width - 1
+            node_scaling = max_width - 1
         s = StringIO()
         print("graph g {", file=s)
         # Using overlap=false would be nice here, but that does not work with some Graphviz builds


### PR DESCRIPTION
If I am interpreting this correctly, dot method is calculating the scale of edges and nodes to be used. It is expecting at least one of the nodes to have n higher than 1, but if all nodes have n=1, then their maximum is. Logarithm of 1 is 0, and this is the denominator used for scaling, which ends up in a division by zero.

I added a try/except for this division and then the scale is just max_width - 1.

This should solve issue #66 . Is this ok?