### PR TITLE
Faster processing of the exclusion list

### DIFF
--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -248,7 +248,7 @@ def run_trex(
         corrected_molecules = [
             molecule
             for molecule in corrected_molecules
-            if not is_similar_to_any(molecule.clone_id, excluded_clone_ids)
+            if molecule.clone_id not in excluded_clone_ids
         ]
         clone_ids = [
             m.clone_id


### PR DESCRIPTION
In summary, processing a long exclusion list (100000 entries) now takes a couple of seconds instead of days.

Previously, we would compare every detected clone id to every clone id in the exclusion list. Each comparison uses the is_similar() function, which implements the comparison by looking at each character of the clone IDs in turn and comparing them.

So if we have *m* detected clone IDs, *n* clone IDs in the exclusion list and clone IDs have a length of *k*, runtime would be O(mnk).

I initially thought that the comparison to each excluded clone ID is necessary because is_similar allows for approximate matches. However, it turns out that is_similar is called with max_hamming=0, that is, only exact matches are allowed anyway, so it is equivalent to just look up each detected clone ID in a set that contains the excluded clone IDs. Runtime becomes effectively O(m) (kind of, if we consider the C-level operations to take constant time).