### PR TITLE
Allow "partial" matches to the exclusion list

### DIFF
--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -1,4 +1,4 @@
-from trex.cli.run10x import is_similar, is_similar_to_any
+from trex.cli.run10x import is_similar, SimilaritySet
 
 import pytest
 
@@ -64,5 +64,6 @@ def test_is_similar(s, t, similar):
         ("AAAAAAAAAA", ["TTTTTTTAAA"], False),
     ],
 )
-def test_is_similar_to_any(s, strings, similar):
-    assert is_similar_to_any(s, strings) == similar
+def test_similarity_set(s, strings, similar):
+    similarity_set = SimilaritySet(strings)
+    assert similarity_set.contains(s) == similar


### PR DESCRIPTION
This fixes a regression introduced in PR #71:
If the clone ID that we look up in the exclusion list contains "-" or "0" characters, we need to check only the other characters. This is now handled by introducing a SimilaritySet class that uses exact lookups as long as there are no "-" or "0", but falls back to the old algorithm otherwise.

This adds a minute or so to processing the exclusion list, so it is slower, overall still much better than runtime on the order of days.