### PR TITLE
Fix overeager filtering when --keep-cross-contamination is used

### DIFF
--- a/src/trex/cli/run10x.py
+++ b/src/trex/cli/run10x.py
@@ -615,7 +615,11 @@ def filter_cells(
             if overall_counts[clone_id] > 1 and discard_cross_contamination:
                 # This cloneID occurs also in other cells - remove it
                 del counts[clone_id]
-            elif clone_id in single_read_clone_ids and discard_single_reads:
+            elif (
+                overall_counts[clone_id] == 1
+                and clone_id in single_read_clone_ids
+                and discard_single_reads
+            ):
                 del counts[clone_id]
         if counts:
             new_cells.append(Cell(cell_id=cell.cell_id, counts=counts))


### PR DESCRIPTION
(And not `--keep-single-reads`)

This fixes a regression introduced by PR #86.

Before the change in that PR, entering the `elif` implied that `counts[clone_id] == 1`. After the change, we enter the `elif` also when `discard_cross_contamination` is False (i.e., `--keep-cross-contamination` is used).

That is, all cloneIDs supported by a single read in the cell are filtered out. (Which is not what we want.)